### PR TITLE
turbohaul_client: treat an unreadable status as still-resident, not as unloaded

### DIFF
--- a/src/turbofit_runtime/turbohaul_client.py
+++ b/src/turbofit_runtime/turbohaul_client.py
@@ -222,7 +222,25 @@ def _model_is_resident(status: dict[str, Any], model: str) -> bool:
             return any(value.get(key) == model for key in ("model_tag", "model", "name", "tag"))
         return False
 
+    def readable(value: Any) -> bool:
+        """Can this entry be compared to a model name at all?"""
+        return isinstance(value, str) or (
+            isinstance(value, dict)
+            and any(key in value for key in ("model_tag", "model", "name", "tag"))
+        )
+
     if matches(status.get("active")) or matches(status.get("idle_hot")):
         return True
     residents = status.get("residents")
-    return isinstance(residents, list) and any(matches(item) for item in residents)
+    if isinstance(residents, list):
+        if any(matches(item) for item in residents):
+            return True
+        # An empty list, or a list of entries we can read and did not match, is a proven
+        # absence. A list whose entries we cannot read is not.
+        if not residents or all(readable(item) for item in residents):
+            return False
+    # A status we cannot read is not a model we have proven absent. `unload_model` treats
+    # False as "the model is gone" and returns, so answering False for an unrecognised shape
+    # reports a false unload and makes its own timeout unreachable. Stay resident instead and
+    # let the caller time out.
+    return True

--- a/tests/test_turbohaul_client.py
+++ b/tests/test_turbohaul_client.py
@@ -6,10 +6,13 @@ from contextlib import contextmanager
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from typing import Any, Iterator
 
+import pytest
+
 from turbofit_runtime.turbohaul_client import (
     TurbohaulClient,
     TurbohaulClientError,
     TurbohaulHTTPError,
+    _model_is_resident,
 )
 
 
@@ -252,3 +255,29 @@ def test_unload_model_fails_if_status_still_reports_resident() -> None:
             assert "did not unload" in str(error)
         else:
             raise AssertionError("expected unload verification failure")
+
+
+@pytest.mark.parametrize(
+    "status",
+    [
+        pytest.param({}, id="empty-status"),
+        pytest.param({"residents": {"0": {"model_tag": "main"}}}, id="residents-not-a-list"),
+        pytest.param({"loaded": [{"model_tag": "main"}]}, id="residents-key-renamed"),
+        pytest.param({"residents": [{"id": "main"}]}, id="entry-key-unrecognised"),
+        pytest.param({"data": {"active": {"model_tag": "main"}}}, id="active-nested"),
+    ],
+)
+def test_unreadable_status_is_not_a_proven_unload(status: dict[str, Any]) -> None:
+    """A status we cannot read must not be reported as "the model is gone".
+
+    `unload_model` returns as soon as `_model_is_resident` is False, so answering False for an
+    unrecognised shape reports a false unload and makes the "did not unload" timeout unreachable.
+    """
+    assert _model_is_resident(status, "main") is True
+
+
+def test_absent_model_is_still_recognised() -> None:
+    """The fail-closed rule must not swallow a genuine unload: an empty or non-matching
+    `residents` list is a proven absence and must stay False."""
+    assert _model_is_resident({"active": None, "residents": []}, "main") is False
+    assert _model_is_resident({"residents": [{"model_tag": "other"}]}, "main") is False


### PR DESCRIPTION
`_model_is_resident` answers a **two-valued** question — resident or not — over a **three-valued** input: resident, absent, or **unreadable**. Unreadable currently collapses into absent.

That's harmless in a query, but its only caller is the unload-verification loop in `unload_model`, which returns as soon as the predicate is `False`:

```python
while True:
    status = self.status()
    if not _model_is_resident(status, model):
        return status                      # <- declares the model unloaded
    if time.monotonic() >= deadline:
        raise TurbohaulClientError(f"Turbohaul did not unload model {model!r} ...")
    time.sleep(poll_interval_s)
```

So a status that can't be parsed is reported as a **successful unload on the first poll**, and the `"did not unload"` timeout — the guard written for exactly this case — becomes **unreachable**, since reaching it requires the predicate to keep returning `True`. The controller then proceeds believing VRAM was freed.

Shapes that hit this while the model is still loaded:

| status | current | with this change |
|---|---|---|
| `{}` (degraded transport) | reports unloaded, 1 poll | times out, raises |
| `{"residents": {...}}` (dict, not list) | reports unloaded, 1 poll | times out, raises |
| `{"loaded": [...]}` (key renamed) | reports unloaded, 1 poll | times out, raises |
| `{"residents": [{"id": "main"}]}` (entry key outside the four tried) | reports unloaded, 1 poll | times out, raises |
| `{"data": {"active": {...}}}` (nested) | reports unloaded, 1 poll | times out, raises |
| **`{"active": None, "residents": []}` (genuine unload)** | **succeeds** | **succeeds — unchanged** |

That `matches()` already tries four different key names (`model_tag`, `model`, `name`, `tag`) suggests the status schema does move between Turbohaul versions; a fifth spelling currently reads as absent.

### The change

Every proven absence stays proven — an empty or non-matching `residents` **list** still returns `False`. Only shapes that cannot be *read* return `True`, so the caller times out and raises instead of reporting a false unload. One branch, no behaviour change on any status the current code understands.

### Tests

Five parametrized unreadable shapes, plus `test_absent_model_is_still_recognised` pinning the genuine-unload path so a future fail-closed change can't hang real unloads. The five **fail on current `main` and pass with this change**; `test_absent_model_is_still_recognised` passes in both.

I ran the suite from `tests/` (the repo-root `__init__.py` confuses collection from the top level) with `PYTHONPATH=src:.` — identical failure set before and after this change (69 pre-existing, environment-related), passing count `261 → 267`. Nothing here regressed; I did not attempt to fix the pre-existing ones.

### Reproduction

Independently reproduced in an isolated container — `--network none`, stdlib only, this module vendored verbatim at `a6326c3d` (`sha256 ec95154d…`) with only the caller's control flow transcribed:

**https://github.com/rhCat/cleanroom-findings/tree/main/findings/turbofit-model-resident-fail-open**

`RUN_LOG.txt` there records 5/5 misread and success-on-poll-1, against a control showing the guard works correctly when the shape *is* recognised. The [patch cleanroom](https://github.com/rhCat/cleanroom-findings/tree/main/findings/turbofit-model-resident-fail-open-patch) records 0/5 with the genuine unload preserved.

Worth noting: my first version of this fix still failed on `{"residents": [{"id": "main"}]}` — a well-typed list, so it took the "readable" path and answered proven-absence from entries it couldn't actually compare. The cleanroom caught that; hence the `readable()` helper rather than a bare `isinstance` check.

### Scope

I have **not** confirmed that a live Turbohaul Manager v0.7 emits any of these shapes — the drift set is constructed from what the parser can't read, so this is a latent fail-open rather than a demonstrated field failure. You'll know the real schema stability far better than I do. Two related spots I noticed but did not touch: `_model_in_flight` (`turbohaul_backend.py:307`) has the same shape, and `_model_resident` at `:311` checks five keys including `idle_hot`/`residents` — two predicates over the same status with different key sets in different files.

Found via static analysis of the claim/error-propagation surface; happy to adjust or drop this if the schema is pinned upstream and the concern doesn't apply.