### PR TITLE
Handle unified-memory GPUs (DGX Spark / GB10) in NVIDIA inventory parse

### DIFF
--- a/src/turbofit_runtime/hardware.py
+++ b/src/turbofit_runtime/hardware.py
@@ -123,9 +123,21 @@ def parse_nvidia_inventory_csv(raw: str) -> tuple[AcceleratorDevice, ...]:
         )
         try:
             parsed_index = int(index)
-            parsed_memory = int(memory_total)
         except ValueError as exc:
             raise ValueError(f"invalid NVIDIA numeric field on row {row_number}") from exc
+        # DGX Spark (GB10) and other unified-memory parts report memory.total
+        # as "[N/A]" via nvidia-smi -- the GPU shares system RAM, so fall back
+        # to that. Mirrors the existing [N/A] handling for compute_capability
+        # and bus_id just below.
+        if memory_total in {"", "N/A", "[N/A]"}:
+            parsed_memory = _system_ram_mb()
+        else:
+            try:
+                parsed_memory = int(memory_total)
+            except ValueError as exc:
+                raise ValueError(
+                    f"invalid NVIDIA numeric field on row {row_number}"
+                ) from exc
         devices.append(
             AcceleratorDevice(
                 index=parsed_index,

--- a/tests/test_hardware.py
+++ b/tests/test_hardware.py
@@ -228,3 +228,22 @@ def test_probe_subprocess_failures_return_no_accelerator(error: Exception) -> No
         system_ram_mb=32768,
     )
     assert fingerprint.topology_key == "no-accelerator"
+
+
+def test_parse_nvidia_inventory_gb10_unified_memory_falls_back_to_system_ram(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # DGX Spark (GB10) reports memory.total as "[N/A]" via nvidia-smi because
+    # the GPU shares unified memory with the CPU. The parser must fall back to
+    # system RAM instead of raising "invalid NVIDIA numeric field".
+    import turbofit_runtime.hardware as hw
+
+    monkeypatch.setattr(hw, "_system_ram_mb", lambda: 131072)
+    raw = "0, GPU-gb10, NVIDIA GB10, [N/A], 12.1, 00000000:01:00.0\n"
+
+    devices = parse_nvidia_inventory_csv(raw)
+
+    assert len(devices) == 1
+    assert devices[0].name == "NVIDIA GB10"
+    assert devices[0].memory_total_mb == 131072
+    assert devices[0].compute_capability == "12.1"


### PR DESCRIPTION
## Problem
On DGX Spark (GB10) — and any unified-memory part — `nvidia-smi --query-gpu=memory.total` returns `[N/A]` because the GPU shares system RAM with the CPU. `parse_nvidia_inventory_csv` calls `int(memory_total)` unconditionally, so **every hardware probe crashes** with `invalid NVIDIA numeric field on row 1`. In practice `turbofit-runtime list`, `set auto`, and the controller all fail — turbofit can't run on a DGX Spark at all, despite Spark being a listed target.

## Fix
Fall back to **system RAM** when `memory.total` is `[N/A]` (on these parts the GPU's usable memory *is* system RAM), mirroring the `[N/A]` handling this same function already applies to `compute_capability` and `bus_id`.

## Test
Adds `test_parse_nvidia_inventory_gb10_unified_memory_falls_back_to_system_ram`. Full `test_hardware.py` suite passes (13/13).

## Repro
On a DGX Spark: `nvidia-smi --query-gpu=memory.total --format=csv` → `[N/A]`; any `turbofit-runtime` command → the crash above. With this patch it detects the device and maps to a tier.

## Follow-up (not in this PR)
turbofit has no profile for a single ~128GB unified device, so it maps the GB10 to the 24GB tier. Worth a separate enhancement/issue.