### PR TITLE
docs: track Spark SGLang DFlash2 benchmark

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 
 ### Model runtime
 
+- Added a separate evidence record for the reported Spark/SGLang Qwen 3.8 27B NVFP4 + DFlash2 lane: 116 aggregate output tok/s at concurrency 10 and 262K configured context. It remains non-promotable until raw harness, exact topology, immutable image digest, workload/latency details, acceptance statistics, and a same-runtime baseline are attached.
 - Added an evidence-gated Qwen 3.8 27B DFlash2 candidate: pinned Inco Q4_K_M draft artifact, pinned z-lab llama.cpp PR runtime, 64K/128K/262K/1M recipes, and a hard no-cross-family guard preserving Bonsai's own DSpark sidecar.
 - Removed DeepSeek V4 Flash 0731 from the active catalog, recipes, downloads, and hardware-tier candidates.
 - Main Auto chain is now Bonsai 27B at 8GB, Qwen 3.8 27B Unleashed UD-IQ3_XXS at 16GB, UD-Q3_K_XL at 24–95GB, and the existing Qwen 3.8 27B 16-bit recipe at 96GB+ until an Unleashed FP16 GGUF is published.

--- a/docs/model-matrix.md
+++ b/docs/model-matrix.md
@@ -48,6 +48,14 @@ The deployable llama.cpp artifacts come from [`ggml-org/Qwen3.8-27B-GGUF`](https
 
 Every file is bound to its Hugging Face LFS SHA-256 and exact byte size in [`references/artifact-manifest.json`](references/artifact-manifest.json). The MTP compiler attaches the sidecar with `--model-draft`; non-MTP variants do not inherit one.
 
+#### Qwen 3.8 27B NVFP4 + DFlash2 on SGLang (Spark candidate)
+
+A separate Spark/SGLang lane is now tracked alongside the llama.cpp Q4 DFlash2 lane. The reported configuration uses `RadixArk/Qwen3.8-27B-NVFP4` revision `554ebba`, `z-lab/Qwen3.8-27B-DFlash2` revision `50307d4c4cde6860d4eee73e2547cd786fe8e8a4`, and `weschera/qwen38-27b-dflash2:2026-08-19`. It reported **116 aggregate output tok/s at concurrency 10** with a configured **262,144-token context**.
+
+This is promising throughput evidence, but it is not compared directly with the existing hash-bound llama.cpp single-stream result. It remains a candidate until the raw harness output, exact Spark topology/fingerprint, immutable container digest, workload shape, latency distribution, DFlash2 acceptance, and a same-SGLang baseline with speculation disabled are attached. The complete launch vector and qualification gaps are preserved in [`references/results/qwen38-nvfp4-dflash2-sglang-spark-c10-20260824.json`](../references/results/qwen38-nvfp4-dflash2-sglang-spark-c10-20260824.json).
+
+The runtime path is grounded in SGLang's upstream DFlash2 merge [`c14312a66420b75ca9a11bf1817c4db1fa26b097`](https://github.com/sgl-project/sglang/commit/c14312a66420b75ca9a11bf1817c4db1fa26b097) and the reference DGX Spark deployment at [`MiaAI-Lab/Qwen3.8-27B-SGLang-DGX-Spark`](https://github.com/MiaAI-Lab/Qwen3.8-27B-SGLang-DGX-Spark). It is not yet an Auto or TurboFit List winner.
+
 #### Ternary Bonsai 27B
 
 Every valid Cartesian combination of:

--- a/references/results/qwen38-nvfp4-dflash2-sglang-spark-c10-20260824.json
+++ b/references/results/qwen38-nvfp4-dflash2-sglang-spark-c10-20260824.json
@@ -1,0 +1,123 @@
+{
+  "schema": "turbofit.reported-throughput/v1",
+  "status": "candidate-user-reported",
+  "recorded_at": "2026-08-24T02:49:50-05:00",
+  "source": {
+    "kind": "user-report",
+    "channel": "discord",
+    "raw_harness_attached": false,
+    "notes": "Reported immediately after a fresh benchmark. Keep separate from hash-bound physical evidence and TurboFit List winners until the raw harness output and hardware fingerprint are attached."
+  },
+  "hardware": {
+    "reported_label": "spark",
+    "class": "unresolved-spark-topology",
+    "device_count": null,
+    "physical_fingerprint": null
+  },
+  "target": {
+    "id": "qwen3-8-27b-radixark-nvfp4",
+    "repo": "RadixArk/Qwen3.8-27B-NVFP4",
+    "reported_revision": "554ebba",
+    "format": "safetensors",
+    "quantization": "NVFP4",
+    "local_mount": "/model"
+  },
+  "draft": {
+    "id": "qwen3-8-27b-dflash2-z-lab",
+    "repo": "z-lab/Qwen3.8-27B-DFlash2",
+    "revision": "50307d4c4cde6860d4eee73e2547cd786fe8e8a4",
+    "reported_size_gb_decimal": 3.85,
+    "local_mount": "/draft"
+  },
+  "runtime": {
+    "id": "sglang-dflash2",
+    "engine": "sglang",
+    "container_image": "weschera/qwen38-27b-dflash2:2026-08-19",
+    "container_digest": null,
+    "upstream_dflash2_merge": "c14312a66420b75ca9a11bf1817c4db1fa26b097",
+    "reference_deployment_repo": "https://github.com/MiaAI-Lab/Qwen3.8-27B-SGLang-DGX-Spark",
+    "reference_deployment_revision": "c90d8c34cf795185ee8de736b7ded9bca3fe0de1"
+  },
+  "launch": {
+    "served_model_name": "qwen38-27b",
+    "host": "0.0.0.0",
+    "port": 30000,
+    "context_length": 262144,
+    "max_running_requests": 10,
+    "arguments": [
+      "python3",
+      "-m",
+      "sglang.launch_server",
+      "--model-path",
+      "/model",
+      "--served-model-name",
+      "qwen38-27b",
+      "--trust-remote-code",
+      "--mem-fraction-static",
+      "0.95",
+      "--attention-backend",
+      "flashinfer",
+      "--chunked-prefill-size",
+      "8192",
+      "--disable-prefill-cuda-graph",
+      "--kv-cache-dtype",
+      "fp8_e4m3",
+      "--mamba-ssm-dtype",
+      "bfloat16",
+      "--mamba-radix-cache-strategy",
+      "extra_buffer",
+      "--context-length",
+      "262144",
+      "--speculative-algorithm",
+      "DFLASH",
+      "--speculative-draft-model-path",
+      "/draft",
+      "--speculative-num-draft-tokens",
+      "8",
+      "--reasoning-parser",
+      "qwen3",
+      "--tool-call-parser",
+      "qwen3_coder",
+      "--sampling-defaults",
+      "model",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "30000",
+      "--max-prefill-tokens",
+      "16384",
+      "--mamba-full-memory-ratio",
+      "4.21",
+      "--max-mamba-cache-size",
+      "40",
+      "--max-running-requests",
+      "10",
+      "--enable-metrics"
+    ]
+  },
+  "measurement": {
+    "metric": "aggregate_output_throughput",
+    "tokens_per_second": 116.0,
+    "concurrency": 10,
+    "context_configured": 262144,
+    "per_request_tokens_per_second": null,
+    "prompt_shape": null,
+    "output_tokens_per_request": null,
+    "duration_seconds": null,
+    "baseline_arm": null,
+    "draft_acceptance": null
+  },
+  "promotion": {
+    "eligible": false,
+    "reason": "Promising reported candidate, but not comparable with TurboFit's hash-bound single-stream llama.cpp A/B and not eligible for Auto/List promotion without raw benchmark output, exact Spark topology/fingerprint, immutable container digest, workload shape, and a same-runtime non-speculative baseline.",
+    "required_next_evidence": [
+      "raw benchmark output",
+      "exact hardware topology and physical fingerprint",
+      "immutable container image digest",
+      "prompt and output-token workload shape",
+      "per-request latency and throughput distribution",
+      "DFlash2 acceptance statistics",
+      "same SGLang NVFP4 target with speculation disabled"
+    ]
+  }
+}

--- a/tests/test_sglang_dflash2_reported_evidence.py
+++ b/tests/test_sglang_dflash2_reported_evidence.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_reported_spark_sglang_lane_is_preserved_without_false_promotion() -> None:
+    payload = json.loads(
+        (
+            ROOT
+            / "references/results/qwen38-nvfp4-dflash2-sglang-spark-c10-20260824.json"
+        ).read_text()
+    )
+
+    assert payload["schema"] == "turbofit.reported-throughput/v1"
+    assert payload["status"] == "candidate-user-reported"
+    assert payload["target"]["repo"] == "RadixArk/Qwen3.8-27B-NVFP4"
+    assert payload["target"]["reported_revision"] == "554ebba"
+    assert payload["draft"]["revision"] == "50307d4c4cde6860d4eee73e2547cd786fe8e8a4"
+    assert payload["runtime"]["upstream_dflash2_merge"] == "c14312a66420b75ca9a11bf1817c4db1fa26b097"
+    assert payload["launch"]["context_length"] == 262144
+    assert payload["launch"]["max_running_requests"] == 10
+    assert payload["measurement"]["tokens_per_second"] == 116.0
+    assert payload["measurement"]["concurrency"] == 10
+    assert payload["measurement"]["metric"] == "aggregate_output_throughput"
+    assert payload["promotion"]["eligible"] is False
+    assert payload["source"]["raw_harness_attached"] is False


### PR DESCRIPTION
## Summary
- records the reported Qwen 3.8 27B NVFP4 + z-lab DFlash2 SGLang launch vector
- preserves 116 aggregate output tok/s at concurrency 10 and 262K configured context
- keeps this separate from the existing llama.cpp single-stream DFlash2 A/B
- explicitly blocks Auto/TurboFit List promotion until raw harness, topology, image digest, workload/latency, acceptance, and same-runtime baseline evidence are attached

## Grounding
- RadixArk target revision preserved exactly as reported: `554ebba`
- z-lab draft pinned to `50307d4c4cde6860d4eee73e2547cd786fe8e8a4`
- SGLang DFlash2 merge pinned to `c14312a66420b75ca9a11bf1817c4db1fa26b097`
- reference Spark deployment pinned to `c90d8c34cf795185ee8de736b7ded9bca3fe0de1`

## Verification
- `PYTHONPATH=src:. pytest -q` → 556 passed
- JSON parse and `git diff --check` pass