### PR TITLE
fix: make release gates follow current evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 
 ### Model runtime
 
+- Re-ran the canonical Qwen 3.8 Q4 baseline/DFlash2 pair on the same dual-RTX-3090 fingerprint: 35.79 versus 45.60 tok/s, 1.273993× speedup, 70% draft acceptance, and 2,839 MiB additional aggregate peak GPU residency. Added a deterministic exporter that refuses mismatched hardware, context, prompt shape, raw hashes, or invalid acceptance counters before emitting self-hashed A/B evidence.
 - Added a separate evidence record for the reported Spark/SGLang Qwen 3.8 27B NVFP4 + DFlash2 lane: 116 aggregate output tok/s at concurrency 10 and 262K configured context. It remains non-promotable until raw harness, exact topology, immutable image digest, workload/latency details, acceptance statistics, and a same-runtime baseline are attached.
 - Added an evidence-gated Qwen 3.8 27B DFlash2 candidate: pinned Inco Q4_K_M draft artifact, pinned z-lab llama.cpp PR runtime, 64K/128K/262K/1M recipes, and a hard no-cross-family guard preserving Bonsai's own DSpark sidecar.
 - Removed DeepSeek V4 Flash 0731 from the active catalog, recipes, downloads, and hardware-tier candidates.

--- a/docs/campaigns.md
+++ b/docs/campaigns.md
@@ -12,6 +12,13 @@ scripts/install-native-runtimes
 scripts/install-native-runtimes --check-only
 
 PYTHONPATH=src:. scripts/turbofit-catalog-campaign run
+
+# After matching baseline and DFlash2 rows succeed, export a comparable,
+# self-hashed A/B record from their immutable campaign results.
+scripts/turbofit-dflash2-ab-evidence \
+  --baseline-row qwen-3-8-27b-q4-k-m-auto-64k \
+  --dflash2-row qwen-3-8-27b-q4-k-m-dflash2-auto-64k \
+  --output references/results/qwen38-dflash2-2x24-YYYYMMDD.json
 ```
 
 Mainline `llama.cpp` serves standard GGUFs, the pinned PrismML fork serves Bonsai/Ternary custom Q1/Q2 and DSpark artifacts, and pinned `ik_llama.cpp` serves GLM 5.2 IQ2_KL with DSA, IndexShare, CPU-MoE, and native MTP. Runtime revisions and binary paths are canonical in [`references/native-runtimes.json`](references/native-runtimes.json). Validate each artifact with its required parser using `scripts/verify-gguf-artifacts`; parsing all artifacts with mainline `llama.cpp` is intentionally invalid because the custom quantization formats require their matching runtimes.
@@ -22,7 +29,7 @@ Inspect progress:
 PYTHONPATH=src:. scripts/turbofit-catalog-campaign status
 ```
 
-Status separates `current_recipe` coverage—whose `pending + resolved + deferred` always equals all 1,620 active rows—from `historical_attempts`, which may contain obsolete runtime failures or successes and is never release eligibility. Deferred rows remain explicit and are never counted as resolved.
+Status separates `current_recipe` coverage—whose `pending + resolved + deferred` always equals all 516 active rows—from `historical_attempts`, which may contain obsolete runtime failures or successes and is never release eligibility. Deferred rows remain explicit and are never counted as resolved.
 
 The campaign is resumable and records failed attempts rather than silently dropping them. Runtime failures preserve command lines, tracebacks, component/gateway logs, telemetry, and hashes in a unique immutable directory under `references/results/catalog-campaign/failures/<row>/<timestamp>/`. State records pin the canonical production-recipe and validation-protocol SHA-256; changing a runtime, artifact, offload policy, command, smoke-request length, or shared-route scheduling automatically requeues stale successes and resets the attempt budget. Each row acquires an exclusive production-service lease before the first GPU-clear gate: Turbofit's controller/gateway are paused, benchmark components run without a port/GPU race, post-run GPU clear is verified, and only services that were previously active are restored. Every successful row requires:
 
@@ -53,7 +60,7 @@ Raw evidence and resumable state live under [`references/results/catalog-campaig
 Runtime fit and decode speed do **not** imply intelligence. Turbofit therefore runs a second durable campaign against each exact production configuration after its native runtime row passes:
 
 ```bash
-# Initialize or inspect all 1,620 configurations × three benchmark levels
+# Initialize or inspect all 516 configurations × three benchmark levels
 PYTHONPATH=src:. scripts/turbofit-intelligence-campaign init
 PYTHONPATH=src:. scripts/turbofit-intelligence-campaign status
 

--- a/docs/model-matrix.md
+++ b/docs/model-matrix.md
@@ -56,6 +56,8 @@ This is promising throughput evidence, but it is not compared directly with the 
 
 The runtime path is grounded in SGLang's upstream DFlash2 merge [`c14312a66420b75ca9a11bf1817c4db1fa26b097`](https://github.com/sgl-project/sglang/commit/c14312a66420b75ca9a11bf1817c4db1fa26b097) and the reference DGX Spark deployment at [`MiaAI-Lab/Qwen3.8-27B-SGLang-DGX-Spark`](https://github.com/MiaAI-Lab/Qwen3.8-27B-SGLang-DGX-Spark). It is not yet an Auto or TurboFit List winner.
 
+The independently runnable llama.cpp lane now also has a fresh same-host A/B on the canonical dual-RTX-3090 fingerprint at 64K context. The stock Q4 row measured **35.79 tok/s** and the DFlash2 row measured **45.60 tok/s**, a hash-bound **1.273993× / 27.3993%** gain with **105/150 draft tokens accepted (70%)** and **2,839 MiB** additional aggregate peak GPU residency. Both arms used the same 26-token prompt, 128-token completion, hardware fingerprint, and configured context. The exporter verifies both raw-result hashes before producing the self-hashed evidence record at [`references/results/qwen38-dflash2-2x24-20260824.json`](../references/results/qwen38-dflash2-2x24-20260824.json).
+
 #### Ternary Bonsai 27B
 
 Every valid Cartesian combination of:

--- a/docs/runtime-backends.md
+++ b/docs/runtime-backends.md
@@ -30,18 +30,18 @@ scripts/install-dspark-runtime install --backend rocm --amdgpu-targets gfx1100
 
 Use the GFX target for the physical AMD GPU. The generated process environment never mixes CUDA and ROCm visibility variables.
 
-## DeepSeek V4 Flash 0731 Q8 plus DSpark
+## Qwen 3.8 Q4 plus DFlash2
 
-The six-file group is revision-pinned and SHA-256-pinned in `runtime-profiles/downloads.json`:
+The active Qwen 3.8 main, projector, and DFlash2 sidecar are revision-pinned and SHA-256-pinned in `runtime-profiles/downloads.json`:
 
 ```bash
 scripts/download-models.py \
-  --group deepseek-v4-flash-0731-q8-dspark \
-  --base-dir "$HOME/Models/storage/gguf/DeepSeek-V4-Flash-0731" \
-  --receipt references/results/deepseek-v4-download-verification.json
+  --group qwen3-8-27b-q4-dflash2 \
+  --base-dir "$HOME/Models/storage/gguf" \
+  --receipt references/results/qwen38-download-verification.json
 ```
 
-The launch recipe uses the static runtime, the first of five main-model shards, the DSpark sidecar, `--spec-type draft-dspark`, `--spec-draft-n-max 3`, automatic CPU/GPU fit, and `--jinja`.
+The launch recipe uses the pinned DFlash2 llama.cpp fork, Qwen Q4_K_M main model, matching vision projector, DFlash2 sidecar, `--spec-type draft-dflash`, `--spec-draft-n-max 7`, automatic CPU/GPU fit, and `--jinja`. Bonsai remains on its own family-matched DSpark sidecar; speculative sidecars are never shared across model families.
 
 ## Lemonade
 
@@ -60,7 +60,7 @@ lemonade backends install vllm:rocm
 
 ## Benchmarking and evidence
 
-- `scripts/turbofit-catalog-campaign` runs the canonical generated main × auxiliary × context matrix (currently 1,620 rows), including all valid pinned DeepSeek, Qwen 3.8, Ternary Bonsai, and Binary Bonsai add-on combinations.
+- `scripts/turbofit-catalog-campaign` runs the canonical generated main × auxiliary × context matrix (currently 516 rows), including all valid pinned Qwen 3.8, Ternary Bonsai, and Binary Bonsai add-on combinations.
 - `scripts/turbofit-deepswe` prepares a pinned DeepSWE/Pier checkout and runs selected finalists against an OpenAI-compatible endpoint.
 - `research/discover_external_benchmarks.py` binds imported DeepSWE evidence to the source artifact SHA-256. External evidence informs discovery but cannot promote a local runtime profile.
 - `scripts/turbofit-completion-check` reports every executable completion gate without converting a failed or missing live run into a success claim.

--- a/references/results/qwen38-dflash2-2x24-20260824.json
+++ b/references/results/qwen38-dflash2-2x24-20260824.json
@@ -1,0 +1,148 @@
+{
+  "arms": {
+    "baseline": {
+      "completion_tokens": 128,
+      "context": 65536,
+      "gpu_peak_mb": {
+        "0": 487,
+        "1": 20341
+      },
+      "main_tps": 35.79419345475209,
+      "prompt_tokens": 26,
+      "raw_result_sha256": "sha256:ee01efa635d889e7d01e04c55ee7e2215aad4992447741e449cdd5079687b40f",
+      "recipe_sha256": "sha256:c35e7f8b7825c524741501db754e2b7a5600ec6e50bf3d4d7174e4feae2cf38c",
+      "row_id": "qwen-3-8-27b-q4-k-m-auto-64k",
+      "runtime_command": [
+        "/home/sovthpaw/.local/share/turbofit/runtimes/llama.cpp-1c3c9674de4d455f1e571bed808252af54932767/build-cuda/bin/llama-server",
+        "-m",
+        "/home/sovthpaw/Models/storage/gguf/Qwen3.8-27B/Qwen3.8-27B-Q4_K_M.gguf",
+        "--host",
+        "127.0.0.1",
+        "--port",
+        "11605",
+        "--alias",
+        "qwen3-8-27b-q4",
+        "-c",
+        "65536",
+        "-ngl",
+        "auto",
+        "--fit",
+        "on",
+        "-fa",
+        "on",
+        "--jinja",
+        "-b",
+        "2048",
+        "-ub",
+        "512",
+        "--cache-type-k",
+        "q4_0",
+        "--cache-type-v",
+        "q4_0",
+        "--parallel",
+        "1",
+        "--mmproj",
+        "/home/sovthpaw/Models/storage/gguf/Qwen3.8-27B/mmproj-Qwen3.8-27B-Q8_0.gguf"
+      ]
+    },
+    "dflash2": {
+      "completion_tokens": 128,
+      "context": 65536,
+      "gpu_peak_mb": {
+        "0": 486,
+        "1": 23181
+      },
+      "main_tps": 45.60155088361084,
+      "prompt_tokens": 26,
+      "raw_result_sha256": "sha256:ad813c49f7b566aeccc3b153fc29a3f26824069124ee8743f1b43c1fcd12ddf1",
+      "recipe_sha256": "sha256:2cc2731bd24ef935511bbbe44221149ed45e7535e0b33c84097b937d3f8cf828",
+      "row_id": "qwen-3-8-27b-q4-k-m-dflash2-auto-64k",
+      "runtime_command": [
+        "/home/sovthpaw/.local/share/turbofit/runtimes/dflash2-llama.cpp-1deefcca395743049c3820ab8f9b15043f3e9446/build-cuda/bin/llama-server",
+        "-m",
+        "/home/sovthpaw/Models/storage/gguf/Qwen3.8-27B/Qwen3.8-27B-Q4_K_M.gguf",
+        "--host",
+        "127.0.0.1",
+        "--port",
+        "11605",
+        "--alias",
+        "qwen3-8-27b-q4-dflash2",
+        "-c",
+        "65536",
+        "-ngl",
+        "auto",
+        "--fit",
+        "on",
+        "-fa",
+        "on",
+        "--jinja",
+        "-b",
+        "2048",
+        "-ub",
+        "512",
+        "--cache-type-k",
+        "q4_0",
+        "--cache-type-v",
+        "q4_0",
+        "--parallel",
+        "1",
+        "--model-draft",
+        "/home/sovthpaw/Models/storage/gguf/Qwen3.8-27B/Qwen3.8-27B-DFlash2-Q4_K_M.gguf",
+        "--spec-type",
+        "draft-dflash",
+        "--spec-draft-n-max",
+        "7",
+        "-ngld",
+        "auto",
+        "--mmproj",
+        "/home/sovthpaw/Models/storage/gguf/Qwen3.8-27B/mmproj-Qwen3.8-27B-Q8_0.gguf"
+      ]
+    }
+  },
+  "comparison": {
+    "accepted_draft_tokens": 105,
+    "additional_peak_gpu_mb": 2839,
+    "baseline_main_tps": 35.79419345475209,
+    "dflash2_main_tps": 45.60155088361084,
+    "draft_acceptance_fraction": 0.7,
+    "draft_tokens": 150,
+    "percent_gain": 27.3993,
+    "same_context": true,
+    "same_hardware": true,
+    "same_prompt": true,
+    "speedup": 1.273993
+  },
+  "evidence_sha256": "sha256:60013593866265755d695fcb1f639a774b85ce2b6d0b3839ac1b50d947f7d87a",
+  "hardware": {
+    "devices": [
+      {
+        "backend": "cuda",
+        "bus_id": "00000000:04:00.0",
+        "compute_capability": "8.6",
+        "index": 0,
+        "memory_total_mb": 24576,
+        "name": "NVIDIA GeForce RTX 3090",
+        "uuid": "GPU-850f05ed-47dc-d111-c850-c3ef2766b8f1",
+        "vendor": "nvidia"
+      },
+      {
+        "backend": "cuda",
+        "bus_id": "00000000:86:00.0",
+        "compute_capability": "8.6",
+        "index": 1,
+        "memory_total_mb": 24576,
+        "name": "NVIDIA GeForce RTX 3090",
+        "uuid": "GPU-ef9a97d6-1efa-797f-fbd3-e20837542aa1",
+        "vendor": "nvidia"
+      }
+    ],
+    "fingerprint_sha256": "sha256:aa8f29e3c3917a04f4301806f0b0f7d33e7267d283e1dfb96264e0ef313d926b",
+    "topology_key": "2x24576mb"
+  },
+  "promotion": {
+    "eligible": true,
+    "reason": "same-hardware, same-prompt, hash-bound physical A/B"
+  },
+  "recorded_at": "2026-08-24T07:59:30.041752+00:00",
+  "schema": "turbofit.dflash2-ab/v2"
+}

--- a/runtime-profiles/downloads.json
+++ b/runtime-profiles/downloads.json
@@ -57,6 +57,14 @@
       "sha256": "31629f53165ab6a7dad8c9847dcfd1fdf55829dac1e6e748f4a68581b0033d34",
       "size_bytes": 18973870432
     },
+    "qwen3-8-27b-dflash2-q4-k-m": {
+      "repo_id": "incoai/Qwen3.8-27B-DFlash2-GGUF",
+      "revision": "6cb5872e2cee6b4e780a8414922350be8e42d65c",
+      "path": "Qwen3.8-27B-DFlash2-Q4_K_M.gguf",
+      "destination": "Qwen3.8-27B/Qwen3.8-27B-DFlash2-Q4_K_M.gguf",
+      "sha256": "18a380efc9b7ed8d88677fc895f5c11ae170653434ee378f7348f715c14d0594",
+      "size_bytes": 1143006752
+    },
     "qwen3-8-27b-qwen3.8-27b-q8-0": {
       "repo_id": "ggml-org/Qwen3.8-27B-GGUF",
       "revision": "0669b98607d47046c7c2b3f801011d54a08cfccf",
@@ -123,6 +131,11 @@
       "qwen3-8-27b-unleashed-ud-iq3-xxs",
       "qwen3-8-27b-unleashed-ud-q3-k-xl",
       "qwen3-8-27b-unleashed-mmproj"
+    ],
+    "qwen3-8-27b-q4-dflash2": [
+      "qwen3-8-27b-qwen3.8-27b-q4-k-m",
+      "qwen3-8-27b-mmproj-qwen3.8-27b-q8-0",
+      "qwen3-8-27b-dflash2-q4-k-m"
     ],
     "ornith-1-5-35a3b": [
       "ornith-1-5-35a3b-q4",

--- a/scripts/turbofit-completion-check
+++ b/scripts/turbofit-completion-check
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
-"""Report executable completion gates for the current Turbofit 2.1 brief."""
+"""Report executable completion gates for the current Turbofit release."""
 from __future__ import annotations
 
 import json
 import hashlib
+import re
 import shutil
 import subprocess
 import sys
@@ -26,16 +27,6 @@ def _load(path: Path, default: Any) -> Any:
         return json.loads(path.read_text(encoding="utf-8"))
     except (FileNotFoundError, json.JSONDecodeError):
         return default
-
-
-def _sha256(path: Path) -> str | None:
-    if not path.is_file():
-        return None
-    digest = hashlib.sha256()
-    with path.open("rb") as handle:
-        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
-            digest.update(chunk)
-    return digest.hexdigest()
 
 
 def _command_ok(command: list[str]) -> tuple[bool, str]:
@@ -63,6 +54,54 @@ def _campaign(path: Path, expected: int) -> dict[str, Any]:
     return {"ok": success == expected and failed == 0, "success": success, "failed": failed, "expected": expected}
 
 
+def _declared_version(text: str) -> str | None:
+    match = re.search(r"(?m)^version:\s*[\"']?([^\"'\s]+)", text)
+    return match.group(1) if match else None
+
+
+def _evidence_hash_matches(payload: dict[str, Any]) -> bool:
+    expected = payload.get("evidence_sha256")
+    if not isinstance(expected, str) or not expected.startswith("sha256:"):
+        return False
+    unsigned = {key: value for key, value in payload.items() if key != "evidence_sha256"}
+    canonical = json.dumps(unsigned, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return expected == "sha256:" + hashlib.sha256(canonical).hexdigest()
+
+
+def production_download_gate(downloads_path: Path, artifact_manifest_path: Path) -> dict[str, Any]:
+    """Cross-check the current production download floor against immutable artifacts."""
+    expected = DownloadCatalog.load(downloads_path).files_for_group("production-floor")
+    manifest = _load(artifact_manifest_path, {"artifacts": []})
+    artifacts = {
+        (str(item.get("repo_id")), str(item.get("path"))): item
+        for item in manifest.get("artifacts", [])
+        if item.get("repo_id") and item.get("path")
+    }
+    missing: list[str] = []
+    mismatched: list[str] = []
+    for item in expected:
+        pinned = artifacts.get((item.repo_id, item.path))
+        if pinned is None:
+            missing.append(item.id)
+            continue
+        expected_identity = {
+            "revision": item.revision,
+            "sha256": item.sha256,
+            "size_bytes": item.size_bytes,
+        }
+        if any(pinned.get(field) != value for field, value in expected_identity.items()):
+            mismatched.append(item.id)
+    verified = len(expected) - len(missing) - len(mismatched)
+    return {
+        "ok": bool(expected) and not missing and not mismatched,
+        "group": "production-floor",
+        "verified": verified,
+        "expected": len(expected),
+        "missing": missing,
+        "mismatched": mismatched,
+    }
+
+
 def report() -> dict[str, Any]:
     configurations = _load(ROOT / "references/configuration-matrix.json", {"rows": []})
     catalog = _load(ROOT / "references/model-catalog.json", {"models": []})
@@ -72,22 +111,15 @@ def report() -> dict[str, Any]:
     tournaments = load_tournaments(ROOT / "references/hardware-tier-tournaments.json", configurations)
     tier_candidates = candidate_ids(tournaments)
     external = _load(ROOT / "research/external-benchmarks.json", {})
-    receipt = _load(ROOT / "references/results/deepseek-v4-download-verification.json", {})
-    dspark_live = _load(ROOT / "references/results/deepseek-v4-dspark-live.json", {})
+    dflash2_ab = _load(ROOT / "references/results/qwen38-dflash2-2x24-20260824.json", {})
     lemonade_live = _load(ROOT / "references/results/lemonade-live.json", {})
     multimodal_catalog = _load(ROOT / "references/multimodal-models.json", {})
     archived_zoo = _load(ROOT / "references/archived-model-zoo.json", {})
-    promo_evidence = _load(ROOT / "promo/production-evidence.json", {})
 
-    expected_downloads = DownloadCatalog.load(ROOT / "runtime-profiles/downloads.json").files_for_group(
-        "deepseek-v4-flash-0731-q8-dspark"
-    )
-    receipt_files = {item.get("id"): item for item in receipt.get("files", [])}
-    downloads_ok = all(
-        item.id in receipt_files
-        and receipt_files[item.id].get("sha256") == item.sha256
-        and receipt_files[item.id].get("size_bytes") == item.size_bytes
-        for item in expected_downloads
+
+    production_downloads = production_download_gate(
+        ROOT / "runtime-profiles/downloads.json",
+        ROOT / "references/artifact-manifest.json",
     )
     dspark_ok, dspark_detail = _command_ok([
         str(ROOT / "scripts/install-dspark-runtime"), "check", "--backend", "cuda",
@@ -141,6 +173,8 @@ def report() -> dict[str, Any]:
     plugin_entry = (ROOT / "__init__.py").read_text(encoding="utf-8")
     plugin_manifest = (ROOT / "plugin.yaml").read_text(encoding="utf-8")
     bundled_skill = (ROOT / "skills/turbofit/SKILL.md").read_text(encoding="utf-8")
+    plugin_version = _declared_version(plugin_manifest)
+    bundled_skill_version = _declared_version(bundled_skill)
     tailnet_source = (ROOT / "src/turbofit_runtime/tailnet.py").read_text(encoding="utf-8")
     multimodal_source = (ROOT / "src/turbofit_runtime/multimodal.py").read_text(encoding="utf-8")
     campaign_backend_source = (ROOT / "src/turbofit_runtime/backend.py").read_text(encoding="utf-8")
@@ -152,7 +186,6 @@ def report() -> dict[str, Any]:
     checks: dict[str, dict[str, Any]] = {
         "canonical_configuration_matrix": {
             "ok": len(configurations.get("rows", [])) == expected_matrix
-            and expected_matrix == 1_620
             and len({item.get("id") for item in configurations.get("rows", [])}) == expected_matrix
             and all(len(item.get("revision", "")) == 40 for item in catalog.get("models", [])),
             "rows": len(configurations.get("rows", [])),
@@ -212,26 +245,28 @@ def report() -> dict[str, Any]:
             "promoted": sum(bool(item.get("winner")) for item in tournaments["tiers"]),
             "expected": 8,
         },
-        "deepseek_artifacts": {
-            "ok": downloads_ok,
-            "verified": len(receipt_files),
-            "expected": len(expected_downloads),
-        },
+        "production_floor_artifacts": production_downloads,
         "qwen38_day_zero_lane": {
             "ok": (ROOT / "scripts/turbofit-model-onboard").exists()
             and (ROOT / "scripts/watch-qwen38-release").exists()
             and (ROOT / "scripts/install-qwen38-watcher").exists()
             and (ROOT / "references/model-onboarding/README.md").exists()
-            and policy.get("replacement_candidate") == "qwen3-8-27b"
+            and policy.get("replacement_candidate") in {item.get("id") for item in catalog.get("models", [])}
             and not deferred_models,
             "replacement_candidate": policy.get("replacement_candidate"),
             "retiring_variants": len(deferred_models),
         },
         "dspark_runtime": {"ok": dspark_ok, "detail": dspark_detail},
-        "dspark_live_tool_call": {
-            "ok": dspark_live.get("schema") == "turbofit.dspark-live/v1"
-            and (dspark_live.get("tool_call") or {}).get("function", {}).get("name") == "get_weather",
-            "backend": dspark_live.get("backend"),
+        "speculative_runtime_evidence": {
+            "ok": dflash2_ab.get("schema") == "turbofit.dflash2-ab/v2"
+            and _evidence_hash_matches(dflash2_ab)
+            and float((dflash2_ab.get("comparison") or {}).get("speedup", 0)) > 1.0
+            and int((dflash2_ab.get("comparison") or {}).get("accepted_draft_tokens", 0)) > 0
+            and (dflash2_ab.get("promotion") or {}).get("eligible") is True,
+            "schema": dflash2_ab.get("schema"),
+            "hash_bound": _evidence_hash_matches(dflash2_ab),
+            "runtime": (((dflash2_ab.get("arms") or {}).get("dflash2") or {}).get("runtime_command") or [None])[0],
+            "speedup": (dflash2_ab.get("comparison") or {}).get("speedup"),
         },
         "lemonade_runtime": {
             "ok": lemonade_ok
@@ -264,14 +299,14 @@ def report() -> dict[str, Any]:
             and "install_sirvir" in plugin_api,
         },
         "hermes_plugin_and_setup_command": {
-            "ok": 'version: "2.1.0"' in plugin_manifest
-            and "version: 2.1.0" in bundled_skill
+            "ok": bool(plugin_version)
+            and plugin_version == bundled_skill_version
             and "provides_commands:" in plugin_manifest
             and "  - turbofit" in plugin_manifest
             and "ctx.register_command" in plugin_entry
             and '"setup", "configure"' in plugin_entry
             and '"", "scan", "rescan", "recommend"' in plugin_entry,
-            "version": "2.1.0" if 'version: "2.1.0"' in plugin_manifest else None,
+            "version": plugin_version if plugin_version == bundled_skill_version else None,
         },
         "exact_combination_settings": {
             "ok": "/api/plugins/turbofit/combinations" in dashboard_js
@@ -311,13 +346,12 @@ def report() -> dict[str, Any]:
             and "refusing to overwrite" in tailnet_source
             and "publish_tailnet" in plugin_tools,
         },
-        "bundled_sirvir_customer_service": {
-            "ok": all(
-                (ROOT / "profiles/sirvir" / name).is_file()
-                for name in ("SOUL.md", "INSTRUCTIONS.md", "config.yaml", "distribution.yaml")
-            )
-            and "install_sirvir_profile" in plugin_tools
-            and "pull request suggestion" in (ROOT / "profiles/sirvir/INSTRUCTIONS.md").read_text(encoding="utf-8").lower(),
+        "github_sirvir_customer_service": {
+            "ok": "install_sirvir_profile" in plugin_tools
+            and '"https://github.com/SouthpawIN/sirvir.git"' in plugin_tools
+            and '"profile",\n            "install"' in plugin_tools
+            and '"profile", "update", "sirvir", "--yes"' in plugin_tools,
+            "source": "https://github.com/SouthpawIN/sirvir.git",
         },
         "multimodal_setup_and_fit": {
             "ok": multimodal_catalog.get("schema") == "turbofit.multimodal-catalog/v1"
@@ -342,15 +376,7 @@ def report() -> dict[str, Any]:
             and {"glm-5-2-2-788bpw", "minimax-m3-q4", "laguna-s2-1-fp16", "laguna-s2-1-q4"}
             == {item.get("id") for item in archived_zoo.get("models", [])},
         },
-        "h3_promo_and_senter_delivery": {
-            "ok": promo_evidence.get("schema") == "turbofit.h3-promo-production/v1"
-            and _sha256(ROOT / "promo/turbofit-2.1-promo.mp4") == (promo_evidence.get("final") or {}).get("sha256")
-            and _sha256(ROOT / "promo/turbofit-2.1-h3-local-promo-discord.mp4") == (promo_evidence.get("delivery") or {}).get("attachment_sha256")
-            and (promo_evidence.get("delivery") or {}).get("via_profile") == "senter"
-            and bool((promo_evidence.get("delivery") or {}).get("message_id"))
-            and (promo_evidence.get("verification") or {}).get("every_required_style_visually_checked") is True,
-            "message_id": (promo_evidence.get("delivery") or {}).get("message_id"),
-        },
+
     }
     return {"complete": all(item["ok"] for item in checks.values()), "checks": checks}
 

--- a/scripts/turbofit-dflash2-ab-evidence
+++ b/scripts/turbofit-dflash2-ab-evidence
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Export a comparable, hash-bound DFlash2 A/B from catalog campaign rows."""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for block in iter(lambda: handle.read(8 * 1024 * 1024), b""):
+            digest.update(block)
+    return "sha256:" + digest.hexdigest()
+
+
+def _load(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"expected JSON object: {path}")
+    return payload
+
+
+def _arm(state_row: dict[str, Any]) -> tuple[dict[str, Any], dict[str, Any]]:
+    if state_row.get("status") != "success":
+        raise ValueError("A/B rows must both have successful campaign status")
+    raw_path = Path(str(state_row.get("raw_result_path", "")))
+    if not raw_path.is_file():
+        raise ValueError(f"raw result is unavailable: {raw_path}")
+    actual_sha = sha256(raw_path)
+    if actual_sha != state_row.get("raw_result_sha256"):
+        raise ValueError(f"raw result SHA-256 mismatch: {raw_path}")
+    raw = _load(raw_path)
+    result = (raw.get("results") or {}).get("main") or {}
+    timings = result.get("timings") or {}
+    usage = result.get("usage") or {}
+    if float(timings.get("predicted_per_second", 0)) <= 0:
+        raise ValueError("A/B row has no positive main throughput")
+    summary = {
+        "row_id": (raw.get("row") or {}).get("id"),
+        "context": (raw.get("row") or {}).get("context"),
+        "main_tps": timings.get("predicted_per_second"),
+        "prompt_tokens": usage.get("prompt_tokens"),
+        "completion_tokens": usage.get("completion_tokens"),
+        "gpu_peak_mb": raw.get("gpu_peak_mb") or {},
+        "raw_result_sha256": actual_sha,
+        "recipe_sha256": state_row.get("recipe_sha256"),
+        "runtime_command": next(
+            (component.get("command") for component in raw.get("components", []) if component.get("role") == "main"),
+            None,
+        ),
+    }
+    return summary, raw
+
+
+def build_evidence(state_path: Path, baseline_id: str, dflash2_id: str) -> dict[str, Any]:
+    state = _load(Path(state_path))
+    rows = state.get("rows") or {}
+    if baseline_id not in rows or dflash2_id not in rows:
+        raise ValueError("both requested A/B rows must exist in campaign state")
+    baseline_state = rows[baseline_id]
+    dflash2_state = rows[dflash2_id]
+    baseline, baseline_raw = _arm(baseline_state)
+    dflash2, dflash2_raw = _arm(dflash2_state)
+
+    baseline_fingerprint = baseline_state.get("physical_fingerprint")
+    dflash2_fingerprint = dflash2_state.get("physical_fingerprint")
+    if not baseline_fingerprint or baseline_fingerprint != dflash2_fingerprint:
+        raise ValueError("A/B rows have different physical fingerprints")
+    for label, raw, expected in (
+        ("baseline", baseline_raw, baseline_fingerprint),
+        ("DFlash2", dflash2_raw, dflash2_fingerprint),
+    ):
+        embedded = (raw.get("physical_hardware") or {}).get("fingerprint_sha256")
+        if embedded != expected:
+            raise ValueError(f"{label} embedded physical fingerprint disagrees with campaign state")
+    if baseline["context"] != dflash2["context"]:
+        raise ValueError("A/B rows have different configured contexts")
+    for field in ("prompt_tokens", "completion_tokens"):
+        if baseline[field] != dflash2[field]:
+            raise ValueError(f"A/B rows have different {field}")
+
+    timings = ((dflash2_raw.get("results") or {}).get("main") or {}).get("timings") or {}
+    draft_tokens = int(timings.get("draft_n", 0))
+    accepted = int(timings.get("draft_n_accepted", 0))
+    if draft_tokens <= 0 or not 0 < accepted <= draft_tokens:
+        raise ValueError("DFlash2 row has invalid draft acceptance counters")
+
+    baseline_tps = float(baseline["main_tps"])
+    dflash2_tps = float(dflash2["main_tps"])
+    speedup = round(dflash2_tps / baseline_tps, 6)
+    baseline_peak = sum(int(value) for value in baseline["gpu_peak_mb"].values())
+    dflash2_peak = sum(int(value) for value in dflash2["gpu_peak_mb"].values())
+    hardware = dflash2_raw.get("physical_hardware") or baseline_raw.get("physical_hardware") or {}
+    payload: dict[str, Any] = {
+        "schema": "turbofit.dflash2-ab/v2",
+        "recorded_at": hardware.get("captured_at"),
+        "hardware": {
+            "fingerprint_sha256": baseline_fingerprint,
+            "topology_key": (hardware.get("fingerprint") or {}).get("topology_key"),
+            "devices": (hardware.get("fingerprint") or {}).get("devices"),
+        },
+        "arms": {"baseline": baseline, "dflash2": dflash2},
+        "comparison": {
+            "baseline_main_tps": baseline_tps,
+            "dflash2_main_tps": dflash2_tps,
+            "speedup": speedup,
+            "percent_gain": round((speedup - 1.0) * 100.0, 6),
+            "additional_peak_gpu_mb": dflash2_peak - baseline_peak,
+            "draft_tokens": draft_tokens,
+            "accepted_draft_tokens": accepted,
+            "draft_acceptance_fraction": accepted / draft_tokens,
+            "same_prompt": True,
+            "same_context": True,
+            "same_hardware": True,
+        },
+        "promotion": {
+            "eligible": dflash2_tps > baseline_tps and accepted > 0,
+            "reason": "same-hardware, same-prompt, hash-bound physical A/B",
+        },
+    }
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    payload["evidence_sha256"] = "sha256:" + hashlib.sha256(canonical).hexdigest()
+    return payload
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--state", type=Path, default=Path("references/catalog-campaign-state.json"))
+    parser.add_argument("--baseline-row", required=True)
+    parser.add_argument("--dflash2-row", required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+    payload = build_evidence(args.state, args.baseline_row, args.dflash2_row)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(json.dumps({"status": "written", "output": str(args.output), "evidence_sha256": payload["evidence_sha256"]}))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_completion_check_release_gate.py
+++ b/tests/test_completion_check_release_gate.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import runpy
+from pathlib import Path
+
+from turbofit_runtime.downloads import DownloadCatalog
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts/turbofit-completion-check"
+
+
+def module() -> dict:
+    return runpy.run_path(str(SCRIPT), run_name="turbofit_completion_check_test")
+
+
+def test_production_download_gate_uses_current_manifest_group() -> None:
+    gate = module()["production_download_gate"](
+        ROOT / "runtime-profiles/downloads.json",
+        ROOT / "references/artifact-manifest.json",
+    )
+
+    assert gate["ok"] is True
+    assert gate["group"] == "production-floor"
+    assert gate["expected"] == 2
+    assert gate["verified"] == 2
+    assert gate["missing"] == []
+    assert gate["mismatched"] == []
+
+
+def test_operator_docs_match_current_catalog_size_and_models() -> None:
+    campaign_docs = (ROOT / "docs/campaigns.md").read_text(encoding="utf-8")
+    backend_docs = (ROOT / "docs/runtime-backends.md").read_text(encoding="utf-8")
+    matrix = __import__("json").loads((ROOT / "references/configuration-matrix.json").read_text(encoding="utf-8"))
+
+    assert len(matrix["rows"]) == 516
+    assert "516 active rows" in campaign_docs
+    assert "currently 516 rows" in backend_docs
+    assert "1,620" not in campaign_docs + backend_docs
+    assert "--group deepseek-v4-flash-0731-q8-dspark" not in backend_docs
+    assert "Qwen 3.8 Q4 plus DFlash2" in backend_docs
+
+
+def test_qwen_dflash2_variant_has_complete_download_group() -> None:
+    catalog = DownloadCatalog.load(ROOT / "runtime-profiles/downloads.json")
+    files = catalog.files_for_group("qwen3-8-27b-q4-dflash2")
+
+    assert {item.destination for item in files} == {
+        "Qwen3.8-27B/Qwen3.8-27B-Q4_K_M.gguf",
+        "Qwen3.8-27B/mmproj-Qwen3.8-27B-Q8_0.gguf",
+        "Qwen3.8-27B/Qwen3.8-27B-DFlash2-Q4_K_M.gguf",
+    }
+
+
+def test_release_gate_derives_current_matrix_candidate_and_version() -> None:
+    loaded = module()
+    loaded["_command_ok"] = lambda _command: (False, "not exercised in metadata test")
+    loaded["_json_command"] = lambda command: (
+        {
+            "matrix": {"total": 516},
+            "current_recipe": {"pending": 516},
+        }
+        if "catalog-campaign" in command[0]
+        else {"levels": {}}
+        if "intelligence-campaign" in command[0]
+        else {"tiers": []}
+    )
+
+    checks = loaded["report"]()["checks"]
+
+    assert checks["canonical_configuration_matrix"]["ok"] is True
+    assert checks["canonical_configuration_matrix"]["expected"] == 516
+    assert checks["qwen38_day_zero_lane"]["ok"] is True
+    assert checks["qwen38_day_zero_lane"]["replacement_candidate"] == "qwen3-8-27b-unleashed-ud-q3-k-xl"
+    assert checks["hermes_plugin_and_setup_command"]["ok"] is True
+    assert checks["hermes_plugin_and_setup_command"]["version"] == "2.3.0"
+    assert "deepseek_artifacts" not in checks
+    assert checks["production_floor_artifacts"]["ok"] is True
+    assert "bundled_sirvir_customer_service" not in checks
+    assert checks["github_sirvir_customer_service"]["ok"] is True
+    assert "dspark_live_tool_call" not in checks
+    assert checks["speculative_runtime_evidence"]["ok"] is True
+    assert checks["speculative_runtime_evidence"]["schema"] == "turbofit.dflash2-ab/v2"
+    assert checks["speculative_runtime_evidence"]["hash_bound"] is True
+    assert "h3_promo_and_senter_delivery" not in checks

--- a/tests/test_dflash2_ab_export.py
+++ b/tests/test_dflash2_ab_export.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import runpy
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts/turbofit-dflash2-ab-evidence"
+
+
+def module() -> dict:
+    return runpy.run_path(str(SCRIPT), run_name="turbofit_dflash2_ab_test")
+
+
+def write_result(
+    path: Path,
+    *,
+    row_id: str,
+    tps: float,
+    peak: int,
+    draft: bool,
+    fingerprint: str = "sha256:fingerprint",
+) -> str:
+    timings = {
+        "predicted_per_second": tps,
+        "predicted_n": 128,
+        "prompt_n": 26,
+    }
+    if draft:
+        timings.update({"draft_n": 150, "draft_n_accepted": 105})
+    payload = {
+        "row": {"id": row_id, "context": 65536},
+        "components": [{"role": "main", "command": ["/runtime/llama-server"]}],
+        "results": {
+            "main": {
+                "usage": {"prompt_tokens": 26, "completion_tokens": 128},
+                "timings": timings,
+            }
+        },
+        "gpu_peak_mb": {"0": 486, "1": peak},
+        "physical_hardware": {
+            "captured_at": "2026-08-24T08:00:00+00:00",
+            "fingerprint": {"topology_key": "2x24576mb", "devices": [{"name": "RTX 3090"}, {"name": "RTX 3090"}]},
+            "fingerprint_sha256": fingerprint,
+        },
+    }
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return "sha256:" + hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def test_build_evidence_exports_comparable_hash_bound_ab(tmp_path: Path) -> None:
+    baseline_id = "baseline"
+    dflash_id = "dflash2"
+    baseline_path = tmp_path / "baseline.json"
+    dflash_path = tmp_path / "dflash.json"
+    baseline_sha = write_result(baseline_path, row_id=baseline_id, tps=35.0, peak=20341, draft=False)
+    dflash_sha = write_result(dflash_path, row_id=dflash_id, tps=45.5, peak=23181, draft=True)
+    state_path = tmp_path / "state.json"
+    state_path.write_text(
+        json.dumps(
+            {
+                "rows": {
+                    baseline_id: {
+                        "status": "success",
+                        "raw_result_path": str(baseline_path),
+                        "raw_result_sha256": baseline_sha,
+                        "recipe_sha256": "sha256:baseline-recipe",
+                        "physical_fingerprint": "sha256:fingerprint",
+                    },
+                    dflash_id: {
+                        "status": "success",
+                        "raw_result_path": str(dflash_path),
+                        "raw_result_sha256": dflash_sha,
+                        "recipe_sha256": "sha256:dflash-recipe",
+                        "physical_fingerprint": "sha256:fingerprint",
+                    },
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    evidence = module()["build_evidence"](state_path, baseline_id, dflash_id)
+
+    assert evidence["schema"] == "turbofit.dflash2-ab/v2"
+    assert evidence["hardware"]["fingerprint_sha256"] == "sha256:fingerprint"
+    assert evidence["arms"]["baseline"]["raw_result_sha256"] == baseline_sha
+    assert evidence["arms"]["dflash2"]["raw_result_sha256"] == dflash_sha
+    assert evidence["comparison"]["baseline_main_tps"] == 35.0
+    assert evidence["comparison"]["dflash2_main_tps"] == 45.5
+    assert evidence["comparison"]["speedup"] == 1.3
+    assert evidence["comparison"]["percent_gain"] == 30.0
+    assert evidence["comparison"]["additional_peak_gpu_mb"] == 2840
+    assert evidence["comparison"]["draft_acceptance_fraction"] == 0.7
+    assert evidence["promotion"]["eligible"] is True
+    assert evidence["evidence_sha256"].startswith("sha256:")
+
+
+def test_build_evidence_refuses_different_hardware(tmp_path: Path) -> None:
+    baseline_path = tmp_path / "baseline.json"
+    dflash_path = tmp_path / "dflash.json"
+    baseline_sha = write_result(baseline_path, row_id="baseline", tps=35.0, peak=20341, draft=False)
+    dflash_sha = write_result(dflash_path, row_id="dflash2", tps=45.5, peak=23181, draft=True)
+    state_path = tmp_path / "state.json"
+    state_path.write_text(
+        json.dumps(
+            {
+                "rows": {
+                    "baseline": {"status": "success", "raw_result_path": str(baseline_path), "raw_result_sha256": baseline_sha, "recipe_sha256": "sha256:a", "physical_fingerprint": "sha256:one"},
+                    "dflash2": {"status": "success", "raw_result_path": str(dflash_path), "raw_result_sha256": dflash_sha, "recipe_sha256": "sha256:b", "physical_fingerprint": "sha256:two"},
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="physical fingerprint"):
+        module()["build_evidence"](state_path, "baseline", "dflash2")
+
+
+def test_build_evidence_refuses_raw_fingerprint_that_disagrees_with_state(tmp_path: Path) -> None:
+    baseline_path = tmp_path / "baseline.json"
+    dflash_path = tmp_path / "dflash.json"
+    baseline_sha = write_result(baseline_path, row_id="baseline", tps=35.0, peak=20341, draft=False)
+    dflash_sha = write_result(
+        dflash_path,
+        row_id="dflash2",
+        tps=45.5,
+        peak=23181,
+        draft=True,
+        fingerprint="sha256:other-hardware",
+    )
+    state_path = tmp_path / "state.json"
+    state_path.write_text(
+        json.dumps(
+            {
+                "rows": {
+                    "baseline": {"status": "success", "raw_result_path": str(baseline_path), "raw_result_sha256": baseline_sha, "recipe_sha256": "sha256:a", "physical_fingerprint": "sha256:fingerprint"},
+                    "dflash2": {"status": "success", "raw_result_path": str(dflash_path), "raw_result_sha256": dflash_sha, "recipe_sha256": "sha256:b", "physical_fingerprint": "sha256:fingerprint"},
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="embedded physical fingerprint"):
+        module()["build_evidence"](state_path, "baseline", "dflash2")


### PR DESCRIPTION
## Summary
- replace stale 2.1/DeepSeek/promo/bundled-Sirvir completion assumptions with current manifest-derived gates
- add a deterministic, hash-validating Qwen 3.8 baseline/DFlash2 A/B evidence exporter and fresh same-host dual-3090 evidence
- add the missing pinned DFlash2 downloader group and align operator docs with the 516-row active matrix

## Measured A/B
- baseline: 35.7942 tok/s
- DFlash2: 45.6016 tok/s
- speedup: 1.273993x (+27.3993%)
- draft acceptance: 105/150 (70%)
- additional aggregate peak GPU residency: 2,839 MiB

## Verification
- `PYTHONPATH=src:. pytest -q` — 563 passed
- `git diff --check`
- JSON parse + Python compile checks
- evidence regenerated byte-for-byte with self-hash `sha256:60013593866265755d695fcb1f639a774b85ce2b6d0b3839ac1b50d947f7d87a`
- completion check now reaches a truthful report; remaining red gates are the unfinished tier/physical/intelligence campaigns and Lemonade live acceptance
