### PR TITLE
fix: improve Windows native setup reliability

### DIFF
--- a/scripts/download-artifacts
+++ b/scripts/download-artifacts
@@ -87,6 +87,13 @@ def install_artifact(
     try:
         os.link(cached, destination)
     except OSError:
+        # Another concurrent setup can materialize the same hard link after
+        # the preflight check. Verify that winner instead of copying over an
+        # identical inode, which raises shutil.SameFileError on Windows.
+        if destination.is_file():
+            if destination.stat().st_size != expected_size or sha256_file(destination) != expected_hash:
+                raise RuntimeError(f"existing artifact does not match manifest: {destination}")
+            return {"destination": str(destination), "downloaded": False, "verified": True}
         shutil.copyfile(cached, destination)
     return {"destination": str(destination), "downloaded": True, "verified": True}
 

--- a/scripts/install-windows-native-service.ps1
+++ b/scripts/install-windows-native-service.ps1
@@ -78,8 +78,12 @@ $arguments = @(
     "--jinja",
     "--metrics"
 )
+$nativeErrorPreference = $ErrorActionPreference
+$ErrorActionPreference = "Continue"
 & $config.binary @arguments *>> $config.log
-exit $LASTEXITCODE
+$exitCode = $LASTEXITCODE
+$ErrorActionPreference = $nativeErrorPreference
+exit $exitCode
 '@
 $launcher = $launcher.Replace("__CONFIG__", $ConfigPath.Replace("'", "''"))
 Set-Content -LiteralPath $LauncherPath -Value $launcher -Encoding UTF8
@@ -103,8 +107,12 @@ $env:TURBOFIT_RUNTIME_STATE = "__ROUTES__"
 $env:TURBOFIT_GATEWAY_PORT = "__PORT__"
 $env:TURBOFIT_GATEWAY_HOST = "__HOST__"
 $env:TURBOFIT_ALLOW_API = "0"
+$nativeErrorPreference = $ErrorActionPreference
+$ErrorActionPreference = "Continue"
 & "__PYTHON__" "__GATEWAY__" *>> "__LOG__"
-exit $LASTEXITCODE
+$exitCode = $LASTEXITCODE
+$ErrorActionPreference = $nativeErrorPreference
+exit $exitCode
 '@
 $gatewayLauncher = $gatewayLauncher.Replace("__ROUTES__", $RoutePath).Replace("__PORT__", [string]$GatewayPort).Replace("__HOST__", $GatewayHost).Replace("__PYTHON__", $Python).Replace("__GATEWAY__", $GatewayScript).Replace("__LOG__", $GatewayLogPath)
 Set-Content -LiteralPath $GatewayLauncherPath -Value $gatewayLauncher -Encoding UTF8

--- a/scripts/turbofit-gateway.py
+++ b/scripts/turbofit-gateway.py
@@ -187,7 +187,7 @@ def active_context_length(default=65536):
     """
     stored = []
     try:
-        with open(RUNTIME_STATE) as f:
+        with open(RUNTIME_STATE, encoding="utf-8-sig") as f:
             state = json.load(f)
         routes = state.get("routes") or {}
         for role in ("main", "aux"):
@@ -239,7 +239,7 @@ def parse_provider_model(model):
 
 def active_profile():
     try:
-        with open(RUNTIME_STATE) as f:
+        with open(RUNTIME_STATE, encoding="utf-8-sig") as f:
             return (json.load(f).get("active") or "").strip() or None
     except Exception:
         return None
@@ -368,7 +368,7 @@ def runtime_override(role):
     without mutating the global catalog between swaps.
     """
     try:
-        with open(RUNTIME_STATE) as f:
+        with open(RUNTIME_STATE, encoding="utf-8-sig") as f:
             state = json.load(f)
     except Exception:
         return None

--- a/src/turbofit_runtime/hardware.py
+++ b/src/turbofit_runtime/hardware.py
@@ -27,6 +27,7 @@ ROCM_INVENTORY_QUERY = [
     "--showbus",
     "--json",
 ]
+VULKAN_INVENTORY_QUERY = ["vulkaninfo"]
 
 
 @dataclass(frozen=True)
@@ -242,6 +243,51 @@ def parse_rocm_smi_json(raw: str) -> tuple[AcceleratorDevice, ...]:
     return tuple(sorted(devices, key=lambda item: (item.bus_id or "", item.index)))
 
 
+def parse_vulkaninfo_text(raw: str) -> tuple[AcceleratorDevice, ...]:
+    """Extract stable Vulkan device identity and dedicated heap capacity."""
+    blocks = re.finditer(
+        r"^GPU(?P<index>\d+):\s*$\n(?P<body>.*?)(?=^GPU\d+:\s*$|\Z)",
+        raw,
+        flags=re.MULTILINE | re.DOTALL,
+    )
+    devices: list[AcceleratorDevice] = []
+    vendor_names = {"0x1002": "amd", "0x10de": "nvidia", "0x8086": "intel"}
+    for block in blocks:
+        body = block.group("body")
+        name_match = re.search(r"^\s*deviceName\s*=\s*(.+)$", body, re.MULTILINE)
+        uuid_match = re.search(r"^\s*deviceUUID\s*=\s*(\S+)$", body, re.MULTILINE)
+        vendor_match = re.search(r"^\s*vendorID\s*=\s*(0x[0-9a-fA-F]+)$", body, re.MULTILINE)
+        heaps_match = re.search(r"^\s*memoryHeaps:.*?\n(?P<heaps>.*?)(?=^\s*memoryTypes:)", body, re.MULTILINE | re.DOTALL)
+        if not (name_match and uuid_match and vendor_match and heaps_match):
+            continue
+        device_local_bytes = 0
+        for heap in re.finditer(
+            r"^\s*memoryHeaps\[\d+\]:\s*$\n(?P<body>.*?)(?=^\s*memoryHeaps\[\d+\]:|\Z)",
+            heaps_match.group("heaps"),
+            re.MULTILINE | re.DOTALL,
+        ):
+            heap_body = heap.group("body")
+            size_match = re.search(r"^\s*size\s*=\s*(\d+)", heap_body, re.MULTILINE)
+            if size_match and "MEMORY_HEAP_DEVICE_LOCAL_BIT" in heap_body:
+                device_local_bytes += int(size_match.group(1))
+        if device_local_bytes <= 0:
+            continue
+        vendor_id = vendor_match.group(1).lower()
+        devices.append(AcceleratorDevice(
+            index=int(block.group("index")),
+            uuid=uuid_match.group(1),
+            name=name_match.group(1).strip(),
+            vendor=vendor_names.get(vendor_id, "vulkan"),
+            backend="vulkan",
+            memory_total_mb=device_local_bytes // (1024 * 1024),
+            compute_capability=None,
+            bus_id=None,
+        ))
+    if not devices:
+        raise ValueError("no Vulkan devices with dedicated memory heaps")
+    return tuple(sorted(devices, key=lambda item: item.index))
+
+
 def probe_hardware(
     *,
     command_runner: Callable[[list[str]], str] | None = None,
@@ -262,6 +308,11 @@ def probe_hardware(
     if not devices and normalized_os == "linux":
         try:
             devices = parse_rocm_smi_json(runner(list(ROCM_INVENTORY_QUERY)))
+        except (FileNotFoundError, OSError, ValueError, subprocess.SubprocessError):
+            devices = ()
+    if not devices and normalized_os == "windows":
+        try:
+            devices = parse_vulkaninfo_text(runner(list(VULKAN_INVENTORY_QUERY)))
         except (FileNotFoundError, OSError, ValueError, subprocess.SubprocessError):
             devices = ()
     if not devices and normalized_os == "darwin" and normalized_architecture in {"arm64", "aarch64"}:

--- a/tests/test_download_artifacts.py
+++ b/tests/test_download_artifacts.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hashlib
 import importlib.util
 from importlib.machinery import SourceFileLoader
+import os
 from pathlib import Path
 
 import pytest
@@ -79,6 +80,34 @@ def test_install_artifact_materializes_cached_symlink_target_not_the_symlink(tmp
     assert destination.is_file()
     assert not destination.is_symlink()
     assert destination.read_bytes() == b"pinned-model"
+
+
+def test_install_artifact_accepts_a_valid_destination_created_during_link(tmp_path: Path, monkeypatch) -> None:
+    module = load_script()
+    cached = tmp_path / "cache" / "model.gguf"
+    cached.parent.mkdir()
+    cached.write_bytes(b"pinned-model")
+    item = {
+        "destination": "family/model.gguf",
+        "repo_id": "owner/repo",
+        "revision": "a" * 40,
+        "path": "remote/model.gguf",
+        "size_bytes": cached.stat().st_size,
+        "sha256": hashlib.sha256(cached.read_bytes()).hexdigest(),
+    }
+    destination = tmp_path / "models" / item["destination"]
+    real_link = os.link
+
+    def link_after_race(source, target):
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        real_link(source, target)
+        raise FileExistsError("another installer already materialized this artifact")
+
+    monkeypatch.setattr(module.os, "link", link_after_race)
+
+    result = module.install_artifact(item, root=tmp_path / "models", download_fn=lambda **_: str(cached))
+
+    assert result == {"destination": str(destination), "downloaded": False, "verified": True}
 
 
 def test_destination_cannot_escape_model_root(tmp_path: Path) -> None:

--- a/tests/test_gateway_runtime_policy.py
+++ b/tests/test_gateway_runtime_policy.py
@@ -26,6 +26,33 @@ def test_gateway_and_controller_share_the_same_default_route_state() -> None:
     assert GATEWAY.RUNTIME_STATE.endswith("/.local/state/turbofit/runtime-state.json")
 
 
+def test_gateway_reads_utf8_bom_runtime_state(tmp_path, monkeypatch) -> None:
+    state = tmp_path / "runtime-state.json"
+    state.write_bytes(
+        b"\xef\xbb\xbf"
+        + json.dumps(
+            {
+                "active": "bom-profile",
+                "routes": {
+                    "main": {
+                        "kind": "local",
+                        "alias": "main",
+                        "port": 8080,
+                        "context_length": 131072,
+                    },
+                    "aux": {"kind": "shared-main", "context_length": 131072},
+                },
+            }
+        ).encode()
+    )
+    monkeypatch.setattr(GATEWAY, "RUNTIME_STATE", str(state))
+    monkeypatch.setattr(GATEWAY, "backend_state", lambda *_args, **_kwargs: "ready")
+
+    assert GATEWAY.active_profile() == "bom-profile"
+    assert GATEWAY.active_context_length() == 131072
+    assert GATEWAY.runtime_override("main")["alias"] == "main"
+
+
 def test_nous_api_auth_uses_hermes_refresh_aware_runtime_credentials(monkeypatch) -> None:
     package = types.ModuleType("hermes_cli")
     package.__path__ = []

--- a/tests/test_hardware.py
+++ b/tests/test_hardware.py
@@ -11,6 +11,7 @@ from turbofit_runtime.hardware import (
     _run_command,
     parse_nvidia_inventory_csv,
     parse_rocm_smi_json,
+    parse_vulkaninfo_text,
     probe_hardware,
 )
 
@@ -182,6 +183,41 @@ def test_probe_falls_back_to_rocm_when_nvidia_is_absent() -> None:
     assert commands[1][0] == "rocm-smi"
     assert fingerprint.backends == ("rocm",)
     assert fingerprint.total_vram_mb == 24576
+
+
+def test_probe_falls_back_to_vulkan_on_windows_with_dedicated_heap_capacity() -> None:
+    raw = """GPU0:
+    vendorID           = 0x1002
+    deviceName         = AMD Radeon RX 6600
+    deviceUUID         = 00112233-4455-6677-8899-aabbccddeeff
+    memoryHeaps: count = 2
+    memoryHeaps[0]:
+        size   = 8304721920
+        budget = 6937617920
+        flags: count = 1
+            MEMORY_HEAP_DEVICE_LOCAL_BIT
+    memoryHeaps[1]:
+        size   = 34317664256
+        budget = 33512374272
+        flags:
+            None
+    memoryTypes: count = 2
+"""
+
+    devices = parse_vulkaninfo_text(raw)
+    fingerprint = probe_hardware(
+        command_runner=lambda command: (_ for _ in ()).throw(FileNotFoundError(command[0]))
+        if command[0] == "nvidia-smi" else raw,
+        os_name="Windows",
+        architecture="amd64",
+        system_ram_mb=65536,
+    )
+
+    assert devices[0].vendor == "amd"
+    assert devices[0].backend == "vulkan"
+    assert devices[0].memory_total_mb == 7920
+    assert fingerprint.topology_key == "1x7920mb"
+    assert fingerprint.backends == ("vulkan",)
 
 
 def test_probe_apple_silicon_exposes_unified_memory_as_metal_capacity() -> None:

--- a/tests/test_windows_native_installer.py
+++ b/tests/test_windows_native_installer.py
@@ -30,6 +30,14 @@ def test_windows_installer_supports_one_step_cuda_cpu_gateway_and_uninstall() ->
     assert '"--alias", "bonsai-27b-1bit-128k-main"' in text
 
 
+def test_windows_installer_does_not_treat_native_stderr_as_a_powershell_failure() -> None:
+    text = SCRIPT.read_text(encoding="utf-8")
+
+    assert text.count('$ErrorActionPreference = "Continue"') >= 2
+    assert text.count("$exitCode = $LASTEXITCODE") >= 2
+    assert text.count("exit $exitCode") >= 2
+
+
 def test_readme_separates_hermes_gateway_from_turbofit_8091() -> None:
     readme = (ROOT / "README.md").read_text()
     windows = (ROOT / "docs" / "windows-native-install.md").read_text()


### PR DESCRIPTION
## Summary
- Preserve native runtime and gateway exit codes when Windows PowerShell captures normal stderr diagnostics.
- Accept UTF-8 BOM-prefixed runtime state written by PowerShell.
- Safely handle concurrent artifact materialization when a valid hard link already exists.
- Discover Vulkan accelerator identity and immutable dedicated heap capacity on Windows when CUDA and ROCm inventory are unavailable.

## Validation
- Targeted Windows startup and gateway regression suite: 21 passed.
- Artifact downloader regression suite: 7 passed.
- Hardware, recommendation, and runtime-profile suites: 62 passed.
- PowerShell parse check passed.
- Live Windows Vulkan probe detects the AMD Radeon RX 6600 with 8176 MiB of dedicated heaps.
- Full release check remains blocked by unrelated Windows portability and optional-dependency failures in the current base branch.