### PR TITLE
feat(desktop): benchmark compatible local models

### DIFF
--- a/dashboard/benchmark_ops.py
+++ b/dashboard/benchmark_ops.py
@@ -1,0 +1,158 @@
+"""Bounded, local candidate benchmarking for the Turbofit Desktop surface."""
+from __future__ import annotations
+
+import math
+import ipaddress
+import tempfile
+import threading
+from numbers import Real
+from pathlib import Path
+from typing import Any, Mapping
+from urllib.parse import urlparse
+
+from plugin_tools import (
+    SELECTION_PATH,
+    _load_json,
+    combination_snapshot,
+    select_profile,
+)
+from product_ops import shift_configuration
+from turbofit_runtime.benchmark_stage import BenchmarkSuite, run_benchmark
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SUITE_PATH = ROOT / "benchmarks" / "stage-v1.json"
+DEFAULT_BASE_URL = "http://127.0.0.1:8091/v1"
+_BENCHMARK_LOCK = threading.Lock()
+RUNTIME_MUTATION_LOCK = _BENCHMARK_LOCK
+
+
+def _validated_benchmark_url(value: str) -> str:
+    parsed = urlparse(str(value or DEFAULT_BASE_URL).strip().rstrip("/"))
+    if parsed.scheme not in {"http", "https"} or not parsed.hostname:
+        raise ValueError("benchmark base_url must be an http(s) URL")
+    if parsed.username or parsed.password or parsed.query or parsed.fragment:
+        raise ValueError("benchmark base_url must not contain credentials, a query, or a fragment")
+    hostname = parsed.hostname.lower().rstrip(".")
+    if hostname == "localhost":
+        host_ok = True
+    else:
+        try:
+            host_ok = ipaddress.ip_address(hostname).is_loopback
+        except ValueError:
+            host_ok = False
+    if not host_ok:
+        raise ValueError("benchmark base_url must target this machine's loopback interface")
+    return str(value or DEFAULT_BASE_URL).strip().rstrip("/")
+
+
+def _candidate_profiles(limit: int) -> list[str]:
+    rows = combination_snapshot().get("combinations") or []
+    profiles: list[str] = []
+    for row in rows:
+        if not isinstance(row, Mapping) or not row.get("fit"):
+            continue
+        profile = str(row.get("profile") or "").strip()
+        if profile and profile not in profiles:
+            profiles.append(profile)
+        if len(profiles) >= limit:
+            break
+    return profiles
+
+
+def benchmark_candidates(
+    *,
+    base_url: str = DEFAULT_BASE_URL,
+    limit: int = 3,
+    timeout_seconds: float = 120.0,
+) -> dict[str, Any]:
+    if isinstance(limit, bool) or not isinstance(limit, int) or not 1 <= limit <= 8:
+        raise ValueError("limit must be an integer from 1 to 8")
+    if isinstance(timeout_seconds, bool) or not isinstance(timeout_seconds, Real) or not math.isfinite(timeout_seconds):
+        raise ValueError("timeout_seconds must be a finite number")
+    if timeout_seconds <= 0 or timeout_seconds > 900:
+        raise ValueError("timeout_seconds must be between 0 and 900")
+    validated_url = _validated_benchmark_url(base_url)
+    with _BENCHMARK_LOCK:
+        return _run_benchmark_candidates(
+            base_url=validated_url,
+            limit=limit,
+            timeout_seconds=float(timeout_seconds),
+        )
+
+
+def _run_benchmark_candidates(
+    *,
+    base_url: str = DEFAULT_BASE_URL,
+    limit: int = 3,
+    timeout_seconds: float = 120.0,
+) -> dict[str, Any]:
+    """Benchmark fit candidates and restore the prior selection afterward."""
+    if isinstance(limit, bool) or not isinstance(limit, int) or not 1 <= limit <= 8:
+        raise ValueError("limit must be an integer from 1 to 8")
+    if timeout_seconds <= 0 or timeout_seconds > 900:
+        raise ValueError("timeout_seconds must be between 0 and 900")
+
+    candidates = _candidate_profiles(limit)
+    if not candidates:
+        return {"ok": False, "status": "blocked", "error": "no physically fitting candidates"}
+
+    previous = _load_json(SELECTION_PATH) or {}
+    previous_profile = str(previous.get("requested") or previous.get("profile_id") or "auto")
+    if previous_profile.startswith("manual-"):
+        previous_profile = previous_profile[7:]
+    suite = BenchmarkSuite.load(SUITE_PATH)
+    results: list[dict[str, Any]] = []
+    restore_error: str | None = None
+    try:
+        for profile in candidates:
+            try:
+                shift = shift_configuration(profile)
+                if not shift.get("shifted"):
+                    raise RuntimeError(shift.get("error") or "candidate could not be activated")
+                with tempfile.TemporaryDirectory(prefix="turbofit-benchmark-") as directory:
+                    evidence = run_benchmark(
+                        suite=suite,
+                        base_url=base_url,
+                        model="auto",
+                        candidate=profile,
+                        configuration=profile,
+                        output_path=Path(directory) / "evidence.json",
+                        timeout_seconds=timeout_seconds,
+                    )
+                results.append({
+                    "profile": profile,
+                    "status": evidence["status"],
+                    "summary": evidence["summary"],
+                    "evidence_sha256": evidence["evidence_sha256"],
+                    "promoted": False,
+                })
+            except Exception as exc:
+                results.append({
+                    "profile": profile,
+                    "status": "fail",
+                    "error": "candidate benchmark failed; inspect Turbofit logs",
+                    "promoted": False,
+                })
+    finally:
+        try:
+            select_profile(previous_profile)
+        except Exception:
+            restore_error = "previous Turbofit profile could not be restored"
+
+    passing = [item for item in results if item.get("status") == "pass"]
+    passing.sort(
+        key=lambda item: float(
+            (item.get("summary") or {}).get("effective_output_tokens_per_second") or 0
+        ),
+        reverse=True,
+    )
+    return {
+        "ok": restore_error is None,
+        "status": "restore_failed" if restore_error else "complete",
+        "error": restore_error,
+        "candidates": results,
+        "best": passing[0] if passing else None,
+        "restored_profile": None if restore_error else previous_profile,
+        "promoted": False,
+    }

--- a/dashboard/plugin_api.py
+++ b/dashboard/plugin_api.py
@@ -25,9 +25,15 @@ from plugin_tools import (  # noqa: E402
     status_snapshot,
 )
 from product_ops import serve_status, serve_tailnet, shift_configuration, update_products  # noqa: E402
+from benchmark_ops import DEFAULT_BASE_URL, RUNTIME_MUTATION_LOCK, benchmark_candidates  # noqa: E402
 
 
 router = APIRouter()
+
+
+def _locked_call(function: Any, *args: Any, **kwargs: Any) -> Any:
+    with RUNTIME_MUTATION_LOCK:
+        return function(*args, **kwargs)
 
 
 def _config() -> dict[str, Any]:
@@ -283,6 +289,7 @@ async def configure(body: dict[str, Any]) -> dict[str, Any]:
         raise HTTPException(status_code=422, detail="Tailscale ports must be integers from 1 to 65535")
     try:
         return await asyncio.to_thread(
+            _locked_call,
             apply_configuration,
             primary=primary,
             fallback=fallback,
@@ -302,6 +309,25 @@ async def configure(body: dict[str, Any]) -> dict[str, Any]:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
 
+@router.post("/benchmark")
+async def post_benchmark(body: dict[str, Any] | None = None) -> dict[str, Any]:
+    payload = body or {}
+    base_url = payload.get("base_url") or DEFAULT_BASE_URL
+    if not isinstance(base_url, str):
+        raise HTTPException(status_code=422, detail="base_url must be a string")
+    try:
+        return await asyncio.to_thread(
+            benchmark_candidates,
+            base_url=base_url,
+            limit=payload.get("limit", 3),
+            timeout_seconds=payload.get("timeout_seconds", 120.0),
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    except Exception:
+        raise HTTPException(status_code=503, detail="local benchmark failed; inspect Turbofit logs") from None
+
+
 @router.post("/update")
 async def post_update() -> dict[str, Any]:
     try:
@@ -317,7 +343,7 @@ async def post_shift(body: dict[str, Any] | None = None) -> dict[str, Any]:
     if not isinstance(target, str):
         raise HTTPException(status_code=422, detail="target must be a string")
     try:
-        return await asyncio.to_thread(shift_configuration, target)
+        return await asyncio.to_thread(_locked_call, shift_configuration, target)
     except Exception as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 

--- a/desktop/plugin.js
+++ b/desktop/plugin.js
@@ -105,6 +105,7 @@ function TurbofitPage() {
   const [providerHttpsPort, setProviderHttpsPort] = useState('9443')
   const [busy, setBusy] = useState(false)
   const [message, setMessage] = useState('')
+  const [benchmark, setBenchmark] = useState(null)
 
   const refresh = useCallback(async () => {
     setBusy(true)
@@ -244,6 +245,24 @@ function TurbofitPage() {
     }
   }
 
+  async function runBenchmark() {
+    setBusy(true)
+    setMessage('Benchmarking physically compatible local candidates…')
+    setBenchmark(null)
+    try {
+      const result = await api.rest('/benchmark', {
+        method: 'POST',
+        body: { base_url: baseUrl, limit: 3, timeout_seconds: 120 },
+      })
+      setBenchmark(result)
+      setMessage(result.best ? `Best measured fit: ${result.best.profile}` : 'Benchmark completed without a passing candidate.')
+    } catch (error) {
+      setMessage(String(error && error.message || error))
+    } finally {
+      setBusy(false)
+    }
+  }
+
   const choices = ((recommendations && recommendations.recommendations) || {})[preference] || []
   const compatibleLanes = (recommendations && recommendations.compatible_lanes) || []
   const hardware = (recommendations && recommendations.hardware) || {}
@@ -277,6 +296,7 @@ function TurbofitPage() {
           jsx('button', { type: 'button', disabled: busy, style: buttonStyle, onClick: () => runShift(preference), children: `Shift ${preference}` }),
           jsx('button', { type: 'button', disabled: busy, style: buttonStyle, onClick: runUpdate, children: 'Update Turbofit + Sirvir' }),
           jsx('button', { type: 'button', disabled: busy, style: buttonStyle, onClick: runServe, children: 'Serve on Tailscale' }),
+          jsx('button', { type: 'button', disabled: busy, style: buttonStyle, onClick: runBenchmark, children: 'Benchmark compatible models' }),
         ],
       }),
       jsxs('div', {
@@ -529,6 +549,18 @@ function TurbofitPage() {
             jsx('div', { className: 'font-medium', children: item.profile }),
             jsx('div', { style: { color: 'var(--ui-text-tertiary)' }, children: `${item.context} ctx · ${item.aux_mode} · ${item.confidence}` }),
             jsx('div', { style: { color: 'var(--ui-text-quaternary)' }, children: item.fit_reason }),
+          ],
+        })),
+      ] }) : null,
+      benchmark ? jsxs('section', { className: 'flex flex-col gap-2', children: [
+        jsx('h2', { className: 'font-semibold', children: 'Local benchmark results' }),
+        jsx('p', { style: { color: 'var(--ui-text-tertiary)' }, children: 'Measured on this machine. Results are not promoted automatically.' }),
+        (benchmark.candidates || []).map((item) => jsxs('div', {
+          key: item.profile,
+          style: { border: '1px solid var(--ui-stroke-secondary)', borderRadius: '6px', padding: '8px' },
+          children: [
+            jsx('div', { className: 'font-medium', children: item.profile }),
+            jsx('div', { style: { color: 'var(--ui-text-tertiary)' }, children: item.error || `${item.status} · ${((item.summary || {}).effective_output_tokens_per_second || '—')} tok/s` }),
           ],
         })),
       ] }) : null,

--- a/plugin_tools.py
+++ b/plugin_tools.py
@@ -679,7 +679,7 @@ def select_profile(profile: str) -> dict[str, Any]:
         raise RuntimeError(payload.get("error") or payload.get("output") or "profile selection failed")
     if combination_id is not None:
         payload["combination_id"] = combination_id
-        active = subprocess.run(
+        active = os.name != "nt" and bool(shutil.which("systemctl")) and subprocess.run(
             ["systemctl", "--user", "is-active", "--quiet", "turbofit-controller.service"],
             check=False,
             timeout=15,

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -361,6 +361,25 @@ def test_desktop_plugin_source_has_status_recommendation_and_fallback_controls()
     assert "Shift up" in text
     assert "Serve on Tailscale" in text
     assert "api.rest('/serve'" in text
+    assert "api.rest('/benchmark'" in text
+    assert "Benchmark compatible models" in text
+    assert "Results are not promoted automatically" in text
+
+
+def test_benchmark_candidates_rejects_unbounded_limits() -> None:
+    from benchmark_ops import benchmark_candidates
+    import pytest
+
+    with pytest.raises(ValueError, match="limit"):
+        benchmark_candidates(limit=0)
+    with pytest.raises(ValueError, match="limit"):
+        benchmark_candidates(limit=9)
+    with pytest.raises(ValueError, match="loopback"):
+        benchmark_candidates(base_url="http://example.com/v1")
+    with pytest.raises(ValueError, match="loopback"):
+        benchmark_candidates(base_url="https://169.254.169.254/v1")
+    with pytest.raises(ValueError, match="finite"):
+        benchmark_candidates(timeout_seconds=float("nan"))
 
 
 def test_apply_configuration_can_install_bundled_sirvir(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- Add a bounded local benchmark action to the Turbofit Desktop tab.
- Test only physically fitting combinations using the existing benchmark-stage suite.
- Restore the prior selected profile after the run.
- Display measured local results without automatic promotion.

## Verification
- `python -m py_compile dashboard/benchmark_ops.py dashboard/plugin_api.py`
- `node --check desktop/plugin.js`
- `git diff --check`
- Plugin API import verified with FastAPI dependencies.

## Notes
- The repository pytest suite is currently blocked during collection by the existing root `__init__.py` relative-import error; no test body runs.
- Unrelated pre-existing working-tree changes were not included.
- Benchmark execution remains local-only and bounded to three candidates by the Desktop action.
