### PR TITLE
fix: Windows follow-ups and honest local smoke

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ hermes plugins install --enable https://github.com/SouthpawIN/Turbofit.git
 /turbofit shift intelligence
 /turbofit serve           # publish :8091 on your tailnet
 /turbofit serve status
+/turbofit smoke           # loopback health of the current local runtime; not a promotion bench
 ```
 
 ```bash

--- a/__init__.py
+++ b/__init__.py
@@ -17,9 +17,9 @@ from .plugin_tools import (
     launch_setup_screen,
     recommendation_snapshot,
 )
-from .product_ops import serve_status, serve_tailnet, shift_configuration, update_products
+from .product_ops import serve_status, serve_tailnet, shift_configuration, smoke_local_runtime, update_products
 
-USAGE = "usage: /turbofit [scan|status|tiers|update|shift up|shift down|shift <model>|serve|intelligence|balanced|speed|setup]"
+USAGE = "usage: /turbofit [scan|status|tiers|update|shift up|shift down|shift <model>|serve|smoke|intelligence|balanced|speed|setup]"
 
 
 def check_available() -> bool:
@@ -61,6 +61,11 @@ def _slash_turbofit(raw_args: str) -> str:
             return json.dumps(serve_status())
         except Exception as exc:
             return json.dumps({"ok": False, "error": str(exc)})
+    if lowered in {"smoke", "check"}:
+        try:
+            return json.dumps(smoke_local_runtime())
+        except Exception as exc:
+            return json.dumps({"ok": False, "error": str(exc)})
     if lowered == "shift" or lowered.startswith("shift "):
         target = action[5:].strip() if lowered.startswith("shift") else ""
         try:
@@ -100,8 +105,8 @@ def register(ctx) -> None:
     ctx.register_command(
         "turbofit",
         _slash_turbofit,
-        description="Scan, shift, serve, or update Turbofit on this machine",
-        args_hint="[scan|status|tiers|update|shift up|shift down|shift <model>|serve|setup]",
+        description="Scan, shift, serve, smoke, or update Turbofit on this machine",
+        args_hint="[scan|status|tiers|update|shift up|shift down|shift <model>|serve|smoke|setup]",
     )
     ctx.register_skill("turbofit", Path(__file__).parent / "SKILL.md")
     try:

--- a/dashboard/plugin_api.py
+++ b/dashboard/plugin_api.py
@@ -24,7 +24,7 @@ from plugin_tools import (  # noqa: E402
     recommendation_snapshot,
     status_snapshot,
 )
-from product_ops import serve_status, serve_tailnet, shift_configuration, update_products  # noqa: E402
+from product_ops import serve_status, serve_tailnet, shift_configuration, smoke_local_runtime, update_products  # noqa: E402
 
 
 router = APIRouter()
@@ -308,6 +308,18 @@ async def post_update() -> dict[str, Any]:
         return await asyncio.to_thread(update_products)
     except Exception as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@router.post("/smoke")
+async def post_smoke(body: dict[str, Any] | None = None) -> dict[str, Any]:
+    payload = body or {}
+    timeout_seconds = payload.get("timeout_seconds", 300.0)
+    try:
+        return await asyncio.to_thread(smoke_local_runtime, timeout_seconds=timeout_seconds)
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    except Exception:
+        raise HTTPException(status_code=503, detail="local smoke failed; inspect Turbofit logs") from None
 
 
 @router.post("/shift")

--- a/dashboard/smoke_ops.py
+++ b/dashboard/smoke_ops.py
@@ -1,0 +1,68 @@
+"""Loopback smoke check of the currently serving Turbofit gateway.
+
+This is not a promotion benchmark. It does not shift production profiles,
+does not take a campaign lease, and never writes a promotion record.
+"""
+from __future__ import annotations
+
+import math
+import os
+import threading
+from datetime import datetime, timezone
+from numbers import Real
+from pathlib import Path
+from typing import Any
+
+from turbofit_runtime.benchmark_stage import BenchmarkSuite, run_benchmark
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SUITE_PATH = ROOT / "benchmarks" / "stage-v1.json"
+DEFAULT_BASE_URL = "http://127.0.0.1:8091/v1"
+_SMOKE_LOCK = threading.Lock()
+
+
+def _evidence_dir() -> Path:
+    state_home = Path(os.getenv("XDG_STATE_HOME", Path.home() / ".local/state"))
+    return state_home / "turbofit" / "smoke"
+
+
+def smoke_local_runtime(*, timeout_seconds: float = 300.0) -> dict[str, Any]:
+    """Run the local smoke suite against 127.0.0.1:8091. Never promotes."""
+    if isinstance(timeout_seconds, bool) or not isinstance(timeout_seconds, Real) or not math.isfinite(timeout_seconds):
+        raise ValueError("timeout_seconds must be a finite number")
+    if timeout_seconds <= 0 or timeout_seconds > 900:
+        raise ValueError("timeout_seconds must be between 0 and 900")
+    with _SMOKE_LOCK:
+        suite = BenchmarkSuite.load(SUITE_PATH)
+        stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+        output_path = _evidence_dir() / f"{stamp}-local-runtime-smoke-v1.json"
+        evidence = run_benchmark(
+            suite=suite,
+            base_url=DEFAULT_BASE_URL,
+            model="auto",
+            candidate="active:main",
+            configuration="active-local-smoke",
+            output_path=output_path,
+            timeout_seconds=float(timeout_seconds),
+            require_gpu_samples=False,
+        )
+        return {
+            "ok": evidence.get("status") == "pass",
+            "status": evidence.get("status"),
+            "suite": suite.name,
+            "promoted": False,
+            "endpoint": DEFAULT_BASE_URL,
+            "evidence_path": str(output_path),
+            "evidence_sha256": evidence.get("evidence_sha256"),
+            "summary": evidence.get("summary"),
+            "request_failures": evidence.get("request_failures") or [],
+            "validator_failures": evidence.get("validator_failures") or [],
+            "resource_failures": evidence.get("resource_failures") or [],
+            "resource_warnings": evidence.get("resource_warnings") or [],
+            "message": (
+                "Local smoke completed. This is not a promotion benchmark."
+                if evidence.get("status") == "pass"
+                else "Local smoke failed. Inspect the evidence file; nothing was promoted."
+            ),
+        }

--- a/desktop/plugin.js
+++ b/desktop/plugin.js
@@ -105,6 +105,7 @@ function TurbofitPage() {
   const [providerHttpsPort, setProviderHttpsPort] = useState('9443')
   const [busy, setBusy] = useState(false)
   const [message, setMessage] = useState('')
+  const [smoke, setSmoke] = useState(null)
 
   const refresh = useCallback(async () => {
     setBusy(true)
@@ -244,6 +245,24 @@ function TurbofitPage() {
     }
   }
 
+  async function runSmoke() {
+    setBusy(true)
+    setMessage('Running local-runtime-smoke-v1 against 127.0.0.1:8091…')
+    setSmoke(null)
+    try {
+      const result = await api.rest('/smoke', {
+        method: 'POST',
+        body: { timeout_seconds: 300 },
+      })
+      setSmoke(result)
+      setMessage(result.message || (result.ok ? 'Local smoke passed. Nothing was promoted.' : 'Local smoke failed. Nothing was promoted.'))
+    } catch (error) {
+      setMessage(String(error && error.message || error))
+    } finally {
+      setBusy(false)
+    }
+  }
+
   const choices = ((recommendations && recommendations.recommendations) || {})[preference] || []
   const compatibleLanes = (recommendations && recommendations.compatible_lanes) || []
   const hardware = (recommendations && recommendations.hardware) || {}
@@ -277,6 +296,7 @@ function TurbofitPage() {
           jsx('button', { type: 'button', disabled: busy, style: buttonStyle, onClick: () => runShift(preference), children: `Shift ${preference}` }),
           jsx('button', { type: 'button', disabled: busy, style: buttonStyle, onClick: runUpdate, children: 'Update Turbofit + Sirvir' }),
           jsx('button', { type: 'button', disabled: busy, style: buttonStyle, onClick: runServe, children: 'Serve on Tailscale' }),
+          jsx('button', { type: 'button', disabled: busy, style: buttonStyle, onClick: runSmoke, children: 'Smoke local runtime' }),
         ],
       }),
       jsxs('div', {
@@ -531,6 +551,13 @@ function TurbofitPage() {
             jsx('div', { style: { color: 'var(--ui-text-quaternary)' }, children: item.fit_reason }),
           ],
         })),
+      ] }) : null,
+      smoke ? jsxs('section', { className: 'flex flex-col gap-2', children: [
+        jsx('h2', { className: 'font-semibold', children: 'Local smoke results' }),
+        jsx('p', { style: { color: 'var(--ui-text-tertiary)' }, children: 'Health check of the currently serving loopback gateway. This is not a promotion benchmark and does not rank models.' }),
+        jsx('div', { style: { border: '1px solid var(--ui-stroke-secondary)', borderRadius: '6px', padding: '8px' }, children: `${smoke.status || 'unknown'} · suite ${smoke.suite || 'local-runtime-smoke-v1'}` }),
+        smoke.evidence_path ? jsx('div', { style: { color: 'var(--ui-text-quaternary)' }, children: smoke.evidence_path }) : null,
+        (smoke.resource_warnings || []).length ? jsx('div', { style: { color: 'var(--ui-text-tertiary)' }, children: `Warnings: ${(smoke.resource_warnings || []).join(', ')}` }) : null,
       ] }) : null,
       jsx('div', {
         style: { color: 'var(--ui-text-quaternary)' },

--- a/plugin_tools.py
+++ b/plugin_tools.py
@@ -679,11 +679,14 @@ def select_profile(profile: str) -> dict[str, Any]:
         raise RuntimeError(payload.get("error") or payload.get("output") or "profile selection failed")
     if combination_id is not None:
         payload["combination_id"] = combination_id
-        active = subprocess.run(
-            ["systemctl", "--user", "is-active", "--quiet", "turbofit-controller.service"],
-            check=False,
-            timeout=15,
-        ).returncode == 0
+        controller_available = os.name != "nt" and bool(shutil.which("systemctl"))
+        active = False
+        if controller_available:
+            active = subprocess.run(
+                ["systemctl", "--user", "is-active", "--quiet", "turbofit-controller.service"],
+                check=False,
+                timeout=15,
+            ).returncode == 0
         if active:
             restarted = subprocess.run(
                 ["systemctl", "--user", "restart", "turbofit-controller.service"],

--- a/product_ops.py
+++ b/product_ops.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import os
 import shutil
 import subprocess
+import sys
 from pathlib import Path
 from typing import Any, Mapping
 
@@ -231,3 +232,13 @@ def serve_tailnet(
 def serve_status() -> dict[str, Any]:
     status = plugin_tools.tailnet_status()
     return {"ok": bool(status.get("connected")), **status}
+
+
+def smoke_local_runtime(*, timeout_seconds: float = 300.0) -> dict[str, Any]:
+    """Slash/Desktop loopback smoke. Does not shift or promote."""
+    dashboard = Path(__file__).resolve().parent / "dashboard"
+    if str(dashboard) not in sys.path:
+        sys.path.insert(0, str(dashboard))
+    from smoke_ops import smoke_local_runtime as run_smoke
+
+    return run_smoke(timeout_seconds=timeout_seconds)

--- a/src/turbofit_runtime/benchmark_stage.py
+++ b/src/turbofit_runtime/benchmark_stage.py
@@ -158,6 +158,7 @@ def run_benchmark(
     process_id: int | None = None, timeout_seconds: float = 900.0,
     artifact_sha256: str | None = None,
     request_options: Mapping[str, Any] | None = None,
+    require_gpu_samples: bool = True,
 ) -> dict[str, Any]:
     cases: list[dict[str, Any]] = []
     all_samples: list[ResourceSample] = []
@@ -196,8 +197,12 @@ def run_benchmark(
     request_failures = [case["id"] for case in cases if case["error"] is not None]
     validator_failures = [case["id"] for case in cases if case["passed"] is False]
     resource_failures = []
+    resource_warnings = []
     if not summary["peak_gpu_memory_used_mib"]:
-        resource_failures.append("gpu-memory-sampling-unavailable")
+        if require_gpu_samples:
+            resource_failures.append("gpu-memory-sampling-unavailable")
+        else:
+            resource_warnings.append("gpu-memory-sampling-unavailable")
     evidence: dict[str, Any] = {
         "schema": EVIDENCE_SCHEMA,
         "recorded_at": datetime.now(timezone.utc).isoformat(),
@@ -213,6 +218,7 @@ def run_benchmark(
         "request_failures": request_failures,
         "validator_failures": validator_failures,
         "resource_failures": resource_failures,
+        "resource_warnings": resource_warnings,
         "summary": summary,
         "cases": cases,
         "resource_samples": [sample.__dict__ for sample in compacted_samples],

--- a/src/turbofit_runtime/hardware.py
+++ b/src/turbofit_runtime/hardware.py
@@ -310,7 +310,7 @@ def probe_hardware(
             devices = parse_rocm_smi_json(runner(list(ROCM_INVENTORY_QUERY)))
         except (FileNotFoundError, OSError, ValueError, subprocess.SubprocessError):
             devices = ()
-    if not devices and normalized_os == "windows":
+    if not devices and normalized_os in {"windows", "linux"}:
         try:
             devices = parse_vulkaninfo_text(runner(list(VULKAN_INVENTORY_QUERY)))
         except (FileNotFoundError, OSError, ValueError, subprocess.SubprocessError):
@@ -341,6 +341,13 @@ def probe_hardware(
     )
 
 
+def _command_timeout(command: list[str]) -> int:
+    name = Path(command[0]).name.lower() if command else ""
+    if name in {"vulkaninfo", "vulkaninfo.exe"}:
+        return 30
+    return 5
+
+
 def _run_command(
     command: list[str],
     *,
@@ -348,8 +355,9 @@ def _run_command(
     compatibility_library_dir: Callable[[], str | None] | None = None,
 ) -> str:
     run = check_output or subprocess.check_output
+    timeout = _command_timeout(command)
     try:
-        return run(command, text=True, timeout=5, stderr=subprocess.PIPE)
+        return run(command, text=True, timeout=timeout, stderr=subprocess.PIPE)
     except subprocess.CalledProcessError:
         if not command or Path(command[0]).name != "nvidia-smi":
             raise
@@ -365,7 +373,7 @@ def _run_command(
         return run(
             command,
             text=True,
-            timeout=5,
+            timeout=timeout,
             stderr=subprocess.PIPE,
             env=env,
         )

--- a/tests/test_hardware.py
+++ b/tests/test_hardware.py
@@ -220,6 +220,41 @@ def test_probe_falls_back_to_vulkan_on_windows_with_dedicated_heap_capacity() ->
     assert fingerprint.backends == ("vulkan",)
 
 
+def test_probe_falls_back_to_vulkan_on_linux_when_cuda_and_rocm_are_absent() -> None:
+    raw = """GPU0:
+    vendorID           = 0x1002
+    deviceName         = AMD Radeon RX 6600
+    deviceUUID         = 00112233-4455-6677-8899-aabbccddeeff
+    memoryHeaps: count = 2
+    memoryHeaps[0]:
+        size   = 8304721920
+        budget = 6937617920
+        flags: count = 1
+            MEMORY_HEAP_DEVICE_LOCAL_BIT
+    memoryHeaps[1]:
+        size   = 34317664256
+        budget = 33512374272
+        flags:
+            None
+    memoryTypes: count = 2
+"""
+
+    def run(command: list[str]) -> str:
+        if command[0] in {"nvidia-smi", "rocm-smi"}:
+            raise FileNotFoundError(command[0])
+        return raw
+
+    fingerprint = probe_hardware(
+        command_runner=run,
+        os_name="linux",
+        architecture="x86_64",
+        system_ram_mb=65536,
+    )
+
+    assert fingerprint.backends == ("vulkan",)
+    assert fingerprint.topology_key == "1x7920mb"
+
+
 def test_probe_apple_silicon_exposes_unified_memory_as_metal_capacity() -> None:
     def missing(_command: list[str]) -> str:
         raise FileNotFoundError("nvidia-smi")
@@ -304,6 +339,19 @@ def test_run_command_retries_nvidia_smi_with_loaded_kernel_compatibility_library
     assert calls[1]["LD_LIBRARY_PATH"].startswith(
         "/home/test/.local/lib/nvidia-580.159.03/usr/lib/x86_64-linux-gnu"
     )
+
+
+def test_run_command_gives_vulkaninfo_a_longer_timeout() -> None:
+    seen: list[int] = []
+
+    def check_output(_command: list[str], *, text: bool, timeout: int, stderr: int) -> str:
+        seen.append(timeout)
+        return "GPU0:\n"
+
+    _run_command(["vulkaninfo"], check_output=check_output)
+    _run_command(["nvidia-smi"], check_output=check_output)
+
+    assert seen == [30, 5]
 
 
 @pytest.mark.parametrize(

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -361,6 +361,9 @@ def test_desktop_plugin_source_has_status_recommendation_and_fallback_controls()
     assert "Shift up" in text
     assert "Serve on Tailscale" in text
     assert "api.rest('/serve'" in text
+    assert "api.rest('/smoke'" in text
+    assert "Smoke local runtime" in text
+    assert "This is not a promotion benchmark" in text
 
 
 def test_apply_configuration_can_install_bundled_sirvir(monkeypatch) -> None:
@@ -787,3 +790,29 @@ def test_select_profile_uses_running_hermes_python(monkeypatch) -> None:
 
     assert plugin_tools.select_profile("auto")["configured"] is True
     assert seen == [[sys.executable, str(ROOT / "scripts" / "turbofit-runtime"), "set", "auto"]]
+
+
+def test_select_profile_skips_systemctl_on_windows(monkeypatch) -> None:
+    import plugin_tools
+
+    seen: list[list[str]] = []
+
+    class Result:
+        returncode = 0
+        stdout = '{"configured": true}'
+        stderr = ""
+
+    def run(command, **_kwargs):
+        seen.append(list(command))
+        return Result()
+
+    monkeypatch.setattr(plugin_tools.os, "name", "nt")
+    monkeypatch.setattr(plugin_tools.shutil, "which", lambda _name: "/usr/bin/systemctl")
+    monkeypatch.setattr(plugin_tools, "prepare_manual_profile", lambda _profile: "manual-x")
+    monkeypatch.setattr(plugin_tools.subprocess, "run", run)
+
+    payload = plugin_tools.select_profile("exact-combo")
+
+    assert payload["configured"] is True
+    assert payload["controller_restarted"] is False
+    assert all(command[0] != "systemctl" for command in seen)

--- a/tests/test_product_ops.py
+++ b/tests/test_product_ops.py
@@ -147,6 +147,10 @@ def test_slash_update_and_shift_are_wired(monkeypatch) -> None:
     assert json.loads(plugin._slash_turbofit("shift bonsai"))["profile"] == "bonsai"
     monkeypatch.setattr(plugin, "serve_tailnet", lambda: {"ok": True, "served": True, "provider_base_url": "https://host.ts.net:9443/v1"})
     assert json.loads(plugin._slash_turbofit("serve"))["served"] is True
+    monkeypatch.setattr(plugin, "smoke_local_runtime", lambda: {"ok": True, "promoted": False, "suite": "local-runtime-smoke-v1"})
+    smoke = json.loads(plugin._slash_turbofit("smoke"))
+    assert smoke["promoted"] is False
+    assert smoke["suite"] == "local-runtime-smoke-v1"
 
 
 def test_serve_tailnet_publishes_provider_url(monkeypatch) -> None:

--- a/tests/test_smoke_ops.py
+++ b/tests/test_smoke_ops.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_smoke_rejects_non_finite_timeout() -> None:
+    import sys
+
+    sys.path.insert(0, str(ROOT / "dashboard"))
+    from smoke_ops import smoke_local_runtime
+
+    with pytest.raises(ValueError, match="finite"):
+        smoke_local_runtime(timeout_seconds=float("nan"))
+    with pytest.raises(ValueError, match="timeout_seconds"):
+        smoke_local_runtime(timeout_seconds=0)
+    with pytest.raises(ValueError, match="timeout_seconds"):
+        smoke_local_runtime(timeout_seconds=901)
+
+
+def test_smoke_persists_evidence_and_never_promotes(tmp_path, monkeypatch) -> None:
+    import sys
+
+    sys.path.insert(0, str(ROOT / "dashboard"))
+    import smoke_ops
+
+    monkeypatch.setattr(smoke_ops, "_evidence_dir", lambda: tmp_path)
+
+    def fake_run(**kwargs):
+        assert kwargs["base_url"] == "http://127.0.0.1:8091/v1"
+        assert kwargs["model"] == "auto"
+        assert kwargs["require_gpu_samples"] is False
+        Path(kwargs["output_path"]).write_text("{}\n", encoding="utf-8")
+        return {
+            "status": "pass",
+            "evidence_sha256": "sha256:abc",
+            "summary": {"effective_output_tokens_per_second": 12.0},
+            "request_failures": [],
+            "validator_failures": [],
+            "resource_failures": [],
+            "resource_warnings": ["gpu-memory-sampling-unavailable"],
+        }
+
+    monkeypatch.setattr(smoke_ops, "run_benchmark", fake_run)
+    result = smoke_ops.smoke_local_runtime()
+
+    assert result["ok"] is True
+    assert result["promoted"] is False
+    assert result["endpoint"] == "http://127.0.0.1:8091/v1"
+    assert result["suite"] == "local-runtime-smoke-v1"
+    assert result["resource_warnings"] == ["gpu-memory-sampling-unavailable"]
+    assert Path(result["evidence_path"]).is_file()
+    assert "shift" not in json.dumps(result)
+
+
+def test_run_benchmark_warns_when_gpu_samples_are_optional(tmp_path, monkeypatch) -> None:
+    from turbofit_runtime import benchmark_stage as stage
+    from turbofit_runtime.benchmark_stage import BenchmarkSuite, run_benchmark
+
+    monkeypatch.setattr(
+        stage,
+        "_chat_completion",
+        lambda **_: {
+            "choices": [{"message": {"content": "ok"}}],
+            "usage": {"prompt_tokens": 8, "completion_tokens": 4},
+        },
+    )
+    monkeypatch.setattr(stage, "evaluate", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(stage, "_gpu_memory_used_mib", lambda: ())
+    monkeypatch.setattr(stage, "hardware_snapshot", lambda: {"os": "windows"})
+    suite = BenchmarkSuite.load(ROOT / "benchmarks" / "stage-v1.json")
+
+    warned = run_benchmark(
+        suite=suite,
+        base_url="http://127.0.0.1:8091/v1",
+        model="auto",
+        candidate="active:main",
+        configuration="test",
+        output_path=tmp_path / "warn.json",
+        require_gpu_samples=False,
+    )
+    failed = run_benchmark(
+        suite=suite,
+        base_url="http://127.0.0.1:8091/v1",
+        model="auto",
+        candidate="active:main",
+        configuration="test",
+        output_path=tmp_path / "fail.json",
+        require_gpu_samples=True,
+    )
+
+    assert warned["status"] == "pass"
+    assert warned["resource_warnings"] == ["gpu-memory-sampling-unavailable"]
+    assert warned["resource_failures"] == []
+    assert failed["status"] == "fail"
+    assert failed["resource_failures"] == ["gpu-memory-sampling-unavailable"]

--- a/tests/test_windows_native_installer.py
+++ b/tests/test_windows_native_installer.py
@@ -49,6 +49,7 @@ def test_readme_separates_hermes_gateway_from_turbofit_8091() -> None:
     assert "docs/windows-native-install.md" in readme
     assert "## Tailscale" in readme
     assert "/turbofit serve" in readme
+    assert "/turbofit smoke" in readme
     assert "Funnel is never used" in readme or "never uses Funnel" in readme
     assert "never from Sirvir" not in skill
     assert "Sirvir handles install" in readme or "Sirvir handles install and setup" in readme


### PR DESCRIPTION
## Why

Follow-ups from #16 plus the honest replacement for #17.

## #16 follow-ups
- `vulkaninfo` timeout is 30s; `nvidia-smi` stays 5s
- Linux Vulkan-only boxes get the same dedicated-heap inventory
- `select_profile` does not call `systemctl` on Windows

## Smoke (replaces #17)
- `/turbofit smoke` and Desktop **Smoke local runtime**
- Hits `http://127.0.0.1:8091/v1` only
- Does not shift production routes or take a campaign lease
- Writes evidence under `~/.local/state/turbofit/smoke`
- Never promotes
- Empty GPU samples are warnings, not failures
- Suite is labeled `local-runtime-smoke-v1` (includes the 8k passkey as a smoke case, not as fit evidence)

## Tests
`105 passed` in the focused hardware/plugin/product/smoke/windows/gateway suites.