### PR TITLE
fix(windows): hide Turbofit scheduled task launchers

### DIFF
--- a/scripts/install-windows-native-service.ps1
+++ b/scripts/install-windows-native-service.ps1
@@ -118,12 +118,12 @@ $gatewayLauncher = $gatewayLauncher.Replace("__ROUTES__", $RoutePath).Replace("_
 Set-Content -LiteralPath $GatewayLauncherPath -Value $gatewayLauncher -Encoding UTF8
 
 $PowerShell = (Get-Command powershell.exe).Source
-$Action = New-ScheduledTaskAction -Execute $PowerShell -Argument "-NoProfile -ExecutionPolicy Bypass -File `"$LauncherPath`""
+$Action = New-ScheduledTaskAction -Execute $PowerShell -Argument "-NoProfile -WindowStyle Hidden -ExecutionPolicy Bypass -File `"$LauncherPath`""
 $Trigger = New-ScheduledTaskTrigger -AtLogOn -User $env:USERNAME
 $Settings = New-ScheduledTaskSettingsSet -RestartCount 5 -RestartInterval (New-TimeSpan -Minutes 1) -ExecutionTimeLimit (New-TimeSpan -Days 3650)
 $Principal = New-ScheduledTaskPrincipal -UserId "$env:USERDOMAIN\$env:USERNAME" -LogonType Interactive -RunLevel Limited
 Register-ScheduledTask -TaskName $TaskName -Action $Action -Trigger $Trigger -Settings $Settings -Principal $Principal -Force | Out-Null
-$GatewayAction = New-ScheduledTaskAction -Execute $PowerShell -Argument "-NoProfile -ExecutionPolicy Bypass -File `"$GatewayLauncherPath`""
+$GatewayAction = New-ScheduledTaskAction -Execute $PowerShell -Argument "-NoProfile -WindowStyle Hidden -ExecutionPolicy Bypass -File `"$GatewayLauncherPath`""
 Register-ScheduledTask -TaskName $GatewayTaskName -Action $GatewayAction -Trigger $Trigger -Settings $Settings -Principal $Principal -Force | Out-Null
 Start-ScheduledTask -TaskName $TaskName
 Start-ScheduledTask -TaskName $GatewayTaskName

--- a/tests/test_windows_native_installer.py
+++ b/tests/test_windows_native_installer.py
@@ -9,6 +9,7 @@ def test_windows_installer_is_user_scoped_jinja_and_health_verified() -> None:
     text = SCRIPT.read_text(encoding="utf-8")
 
     assert "Register-ScheduledTask" in text
+    assert "-WindowStyle Hidden" in text
     assert "-RunLevel Limited" in text
     assert '"--jinja"' in text
     assert '"--fit", "on"' in text


### PR DESCRIPTION
## Summary
- launch Windows Turbofit runtime and gateway scheduled tasks with hidden PowerShell windows
- preserve the existing interactive user-scoped task behavior and add a regression assertion

## Verification
- `uv run --with pytest --with pyyaml pytest tests/test_windows_native_installer.py -q -o addopts=` — 4 passed
- Full suite on Windows: 538 passed, 29 unrelated pre-existing environment/platform failures (optional dependencies, POSIX path assumptions, and Windows socket behavior)
- `scripts/release-check` is blocked on this host because it hard-codes unavailable `python3`/pytest resolution; no release-gate claim made

Observed on Windows 10 with Turbofit runtime and gateway: two visible launcher windows were opened at login. The change was manually verified by the scheduled tasks running with `-WindowStyle Hidden`, with runtime and gateway health restored.