### PR TITLE
fix(windows): accept Vulkan 8 GB reporting delta

### DIFF
--- a/src/turbofit_runtime/recommend.py
+++ b/src/turbofit_runtime/recommend.py
@@ -16,6 +16,10 @@ WORKING_CONTEXT = 262_144
 MAX_CONTEXT = 1_048_576
 INTERACTIVE_TPS = 30.0
 FAST_TPS = 50.0
+# Windows Vulkan drivers can report a dedicated 8 GiB device as 8,176 MiB
+# (16 MiB below the binary tier). Keep the physical tier boundary strict
+# apart from that documented reporting delta.
+DEDICATED_VRAM_REPORTING_TOLERANCE_MB = 16
 _DIGEST_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
 _TOPOLOGY_PART_RE = re.compile(r"^(\d+)x(\d+)(?:gb)?$", re.IGNORECASE)
 
@@ -149,6 +153,8 @@ def hardware_satisfies(
     if hardware.total_usable_memory_mb < _gb_to_mb(constraint.total_vram_gb):
         return False
     minimum_mb = _gb_to_mb(constraint.per_device_min_gb)
+    if not shared_local:
+        minimum_mb = max(0, minimum_mb - DEDICATED_VRAM_REPORTING_TOLERANCE_MB)
     capable_devices = (
         constraint.min_devices if shared_local and hardware.total_usable_memory_mb >= minimum_mb
         else sum(device.memory_total_mb >= minimum_mb for device in devices)

--- a/tests/test_hardware_profiles.py
+++ b/tests/test_hardware_profiles.py
@@ -125,6 +125,47 @@ def test_hardware_envelopes_match_their_canonical_topologies() -> None:
         assert hardware_satisfies(fingerprint(tuple(sizes)), profile.hardware)
 
 
+def test_dedicated_8gb_tier_allows_only_the_windows_vulkan_reporting_delta() -> None:
+    profile = load_yaml_profile(ROOT / "runtime-profiles" / "8gb.yaml")
+    windows_vulkan = HardwareFingerprint(
+        os="windows",
+        architecture="amd64",
+        system_ram_mb=65_455,
+        devices=(
+            AcceleratorDevice(
+                index=0,
+                uuid="00000000-0900-0000-0000-000000000000",
+                name="AMD Radeon RX 6600",
+                vendor="amd",
+                backend="vulkan",
+                memory_total_mb=8_176,
+                compute_capability=None,
+                bus_id=None,
+            ),
+        ),
+    )
+    undersized = HardwareFingerprint(
+        os="windows",
+        architecture="amd64",
+        system_ram_mb=65_455,
+        devices=(
+            AcceleratorDevice(
+                index=0,
+                uuid="00000000-0900-0000-0000-000000000001",
+                name="AMD Radeon RX 6600",
+                vendor="amd",
+                backend="vulkan",
+                memory_total_mb=8_175,
+                compute_capability=None,
+                bus_id=None,
+            ),
+        ),
+    )
+
+    assert hardware_satisfies(windows_vulkan, profile.hardware)
+    assert not hardware_satisfies(undersized, profile.hardware)
+
+
 def test_large_shared_memory_pools_are_not_rejected_by_discrete_card_topology() -> None:
     profile = load_yaml_profile(ROOT / "runtime-profiles" / "96gb.yaml")
     cpu = HardwareFingerprint("linux", "x86_64", 131_072)


### PR DESCRIPTION
## Summary
- accept the exact 16 MiB Windows/Vulkan dedicated-VRAM reporting delta for canonical dedicated tiers
- cover AMD Radeon RX 6600 reporting 8,176 MiB as eligible for the 8 GB Bonsai 64K lane
- retain rejection at 8,175 MiB

## Customer evidence
On Windows 10, the Turbofit probe identified an AMD Radeon RX 6600 Vulkan device with 8,176 MiB. The exact 8,192 MiB profile threshold rejected Auto, leaving an older 48 GB / 131K selection in place and causing multi-minute CLI prefill delays.

## Verification
- Direct regression function: PASS
- Exact Auto replay: hardware-8gb / local-bonsai-65536 / 65536
- python -m py_compile src/turbofit_runtime/recommend.py tests/test_hardware_profiles.py: PASS
- git diff --check: PASS
- scripts/release-check: blocked on this Windows host before tests because its python3 launcher is unavailable.
