### PR TITLE
fix(dashboard): treat empty configuration catalogs as available

### DIFF
--- a/plugin_tools.py
+++ b/plugin_tools.py
@@ -840,7 +840,8 @@ def combination_snapshot() -> dict[str, Any]:
         rows = json.loads(result.stdout)
     except ValueError as exc:
         raise RuntimeError((result.stderr or "failed to enumerate exact combinations").strip()) from exc
-    if result.returncode or not isinstance(rows, list):
+    no_match = result.returncode == 1 and rows == []
+    if (result.returncode and not no_match) or not isinstance(rows, list):
         raise RuntimeError((result.stderr or "failed to enumerate exact combinations").strip())
     from turbofit_runtime.catalog_campaign import build_configuration_index
     from turbofit_runtime.model_catalog import ModelCatalog

--- a/references/configuration-matrix.json
+++ b/references/configuration-matrix.json
@@ -3612,6 +3612,174 @@
       "auxiliary": "auto",
       "context": 1048576,
       "status": "candidate"
+    },
+    {
+      "id": "ornith-1-5-oq4e-mtp--ornith-1-5-35a3b--64k",
+      "main": "ornith-1-5-oq4e-mtp",
+      "auxiliary": "ornith-1-5-35a3b",
+      "context": 65536,
+      "status": "candidate"
+    },
+    {
+      "id": "ornith-1-5-oq4e-mtp--ornith-1-5-35a3b--128k",
+      "main": "ornith-1-5-oq4e-mtp",
+      "auxiliary": "ornith-1-5-35a3b",
+      "context": 131072,
+      "status": "candidate"
+    },
+    {
+      "id": "ornith-1-5-oq4e-mtp--ornith-1-5-35a3b--262k",
+      "main": "ornith-1-5-oq4e-mtp",
+      "auxiliary": "ornith-1-5-35a3b",
+      "context": 262144,
+      "status": "candidate"
+    },
+    {
+      "id": "ornith-1-5-oq4e-mtp--ornith-1-5-35a3b--1m",
+      "main": "ornith-1-5-oq4e-mtp",
+      "auxiliary": "ornith-1-5-35a3b",
+      "context": 1048576,
+      "status": "candidate"
+    },
+    {
+      "id": "ornith-1-5-oq4e-mtp--carwin-nano--64k",
+      "main": "ornith-1-5-oq4e-mtp",
+      "auxiliary": "carwin-nano",
+      "context": 65536,
+      "status": "candidate"
+    },
+    {
+      "id": "ornith-1-5-oq4e-mtp--carwin-nano--128k",
+      "main": "ornith-1-5-oq4e-mtp",
+      "auxiliary": "carwin-nano",
+      "context": 131072,
+      "status": "candidate"
+    },
+    {
+      "id": "ornith-1-5-oq4e-mtp--carwin-nano--262k",
+      "main": "ornith-1-5-oq4e-mtp",
+      "auxiliary": "carwin-nano",
+      "context": 262144,
+      "status": "candidate"
+    },
+    {
+      "id": "ornith-1-5-oq4e-mtp--carwin-nano--1m",
+      "main": "ornith-1-5-oq4e-mtp",
+      "auxiliary": "carwin-nano",
+      "context": 1048576,
+      "status": "candidate"
+    },
+    {
+      "id": "ornith-1-5-oq4e-mtp--auto--64k",
+      "main": "ornith-1-5-oq4e-mtp",
+      "auxiliary": "auto",
+      "context": 65536,
+      "status": "candidate"
+    },
+    {
+      "id": "ornith-1-5-oq4e-mtp--auto--128k",
+      "main": "ornith-1-5-oq4e-mtp",
+      "auxiliary": "auto",
+      "context": 131072,
+      "status": "candidate"
+    },
+    {
+      "id": "ornith-1-5-oq4e-mtp--auto--262k",
+      "main": "ornith-1-5-oq4e-mtp",
+      "auxiliary": "auto",
+      "context": 262144,
+      "status": "candidate"
+    },
+    {
+      "id": "ornith-1-5-oq4e-mtp--auto--1m",
+      "main": "ornith-1-5-oq4e-mtp",
+      "auxiliary": "auto",
+      "context": 1048576,
+      "status": "candidate"
+    },
+    {
+      "id": "ornith-1-5-oq8e-mtp--ornith-1-5-35a3b--64k",
+      "main": "ornith-1-5-oq8e-mtp",
+      "auxiliary": "ornith-1-5-35a3b",
+      "context": 65536,
+      "status": "candidate"
+    },
+    {
+      "id": "ornith-1-5-oq8e-mtp--ornith-1-5-35a3b--128k",
+      "main": "ornith-1-5-oq8e-mtp",
+      "auxiliary": "ornith-1-5-35a3b",
+      "context": 131072,
+      "status": "candidate"
+    },
+    {
+      "id": "ornith-1-5-oq8e-mtp--ornith-1-5-35a3b--262k",
+      "main": "ornith-1-5-oq8e-mtp",
+      "auxiliary": "ornith-1-5-35a3b",
+      "context": 262144,
+      "status": "candidate"
+    },
+    {
+      "id": "ornith-1-5-oq8e-mtp--ornith-1-5-35a3b--1m",
+      "main": "ornith-1-5-oq8e-mtp",
+      "auxiliary": "ornith-1-5-35a3b",
+      "context": 1048576,
+      "status": "candidate"
+    },
+    {
+      "id": "ornith-1-5-oq8e-mtp--carwin-nano--64k",
+      "main": "ornith-1-5-oq8e-mtp",
+      "auxiliary": "carwin-nano",
+      "context": 65536,
+      "status": "candidate"
+    },
+    {
+      "id": "ornith-1-5-oq8e-mtp--carwin-nano--128k",
+      "main": "ornith-1-5-oq8e-mtp",
+      "auxiliary": "carwin-nano",
+      "context": 131072,
+      "status": "candidate"
+    },
+    {
+      "id": "ornith-1-5-oq8e-mtp--carwin-nano--262k",
+      "main": "ornith-1-5-oq8e-mtp",
+      "auxiliary": "carwin-nano",
+      "context": 262144,
+      "status": "candidate"
+    },
+    {
+      "id": "ornith-1-5-oq8e-mtp--carwin-nano--1m",
+      "main": "ornith-1-5-oq8e-mtp",
+      "auxiliary": "carwin-nano",
+      "context": 1048576,
+      "status": "candidate"
+    },
+    {
+      "id": "ornith-1-5-oq8e-mtp--auto--64k",
+      "main": "ornith-1-5-oq8e-mtp",
+      "auxiliary": "auto",
+      "context": 65536,
+      "status": "candidate"
+    },
+    {
+      "id": "ornith-1-5-oq8e-mtp--auto--128k",
+      "main": "ornith-1-5-oq8e-mtp",
+      "auxiliary": "auto",
+      "context": 131072,
+      "status": "candidate"
+    },
+    {
+      "id": "ornith-1-5-oq8e-mtp--auto--262k",
+      "main": "ornith-1-5-oq8e-mtp",
+      "auxiliary": "auto",
+      "context": 262144,
+      "status": "candidate"
+    },
+    {
+      "id": "ornith-1-5-oq8e-mtp--auto--1m",
+      "main": "ornith-1-5-oq8e-mtp",
+      "auxiliary": "auto",
+      "context": 1048576,
+      "status": "candidate"
     }
   ]
 }

--- a/tests/test_model_catalog.py
+++ b/tests/test_model_catalog.py
@@ -19,7 +19,7 @@ MATRIX_PATH = ROOT / "references" / "configuration-matrix.json"
 
 def test_catalog_has_every_requested_main_and_auxiliary_variant() -> None:
     catalog = ModelCatalog.load(CATALOG_PATH)
-    assert len(catalog.main_models) == 43
+    assert len(catalog.main_models) == 45
     unleashed = next(item for item in catalog.main_models if item.id == "qwen3-8-27b-unleashed-ud-q3-k-xl")
     assert unleashed.source == "https://huggingface.co/outsourc-e/Qwen3.8-27B-Unleashed-GGUF"
     assert unleashed.upstream_source == "https://huggingface.co/JonathanColetti/Qwen3.8-27B-Uncensored"
@@ -38,7 +38,7 @@ def test_complete_matrix_is_generated_not_hand_maintained() -> None:
     matrix = json.loads(MATRIX_PATH.read_text())
     validate_configuration_matrix(matrix, catalog)
     expected = len(catalog.main_models) * len(catalog.auxiliary_options) * len(CONTEXTS)
-    assert expected == 516
+    assert expected == 540
     assert len(matrix["rows"]) == expected
     assert len({item["id"] for item in matrix["rows"]}) == expected
     assert {item["context"] for item in matrix["rows"]} == set(CONTEXTS)

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -586,6 +586,24 @@ def test_combination_snapshot_requests_portable_fit_lanes(monkeypatch) -> None:
     assert calls[0][calls[0].index("--evidence-scope") + 1] == "portable-fit"
 
 
+def test_combination_snapshot_accepts_empty_json_from_no_match_exit(monkeypatch) -> None:
+    import plugin_tools
+
+    class Result:
+        stdout = "[]"
+        stderr = ""
+        returncode = 1
+
+    monkeypatch.setattr(plugin_tools.subprocess, "run", lambda *args, **kwargs: Result())
+
+    payload = plugin_tools.combination_snapshot()
+
+    assert payload["ok"] is True
+    assert payload["combinations"] == []
+    assert payload["compatible"] == 0
+    assert payload["total"] == 0
+
+
 def test_recommendation_snapshot_exposes_unmeasured_compatible_lanes(monkeypatch) -> None:
     import plugin_tools
     monkeypatch.setattr(plugin_tools, "ensure_recommended_models", lambda **_: {"ok": True, "families": ["bonsai-27b"], "artifacts": []})


### PR DESCRIPTION
## Summary

Fixes the Turbofit Desktop tab returning HTTP 503 when the recommender produces a valid empty JSON catalog (`[]`) with exit code 1.

- Treat only the documented no-match result (`exit 1` + `[]`) as a successful empty combinations response.
- Regenerate `configuration-matrix.json` from the current model catalog.
- Update stale 43/516 catalog/matrix assertions to the current 45/540 generated values.
- Add a regression test for the exact empty-catalog subprocess contract.

## Reproduction

On Windows/Vulkan with an AMD RX 6600 reporting 8,176 MiB, the updated strict hardware catalog has no portable-fit rows. `scripts/turbofit-runtime-recommend --json --evidence-scope portable-fit` returns `[]` and exits 1. The dashboard previously surfaced that expected no-match state as HTTP 503, even while the local Turbofit gateway and backend were healthy.

## Verification

- `uv run --with pytest --with pyyaml python -c "... pytest focused plugin + model-catalog tests ..."` → `6 passed`
- Invoked the five dashboard refresh handlers directly: `/status`, `/combinations`, `/recommendations`, `/multimodal`, and `/local-models` all returned HTTP-success payloads; `/combinations` returned an empty catalog rather than 503.
- Live local gateway health remained `main: ready`, `aux: ready`.

## Notes

This does not claim the RX 6600 has a measured current-catalog recommendation. It makes the unavailability state observable without falsely reporting an infrastructure failure.