### PR TITLE
fix(windows): resolve native runtime executable

### DIFF
--- a/scripts/install-native-runtimes
+++ b/scripts/install-native-runtimes
@@ -40,6 +40,13 @@ def cmake_configuration(backend: str) -> tuple[str, str]:
         raise ValueError(f"unsupported native backend: {backend}") from exc
 
 
+def native_server_binary(source: Path, build_dir: str) -> Path:
+    root = source / build_dir / "bin"
+    if os.name == "nt":
+        return root / "Release" / "llama-server.exe"
+    return root / "llama-server"
+
+
 def detect_backend() -> str:
     explicit = os.getenv("TURBOFIT_ACCELERATOR_BACKEND", "").lower()
     if explicit:
@@ -60,7 +67,7 @@ def install(runtime: dict, *, backend: str, check_only: bool) -> dict:
     cuda_binary = Path(os.path.expanduser(runtime["cuda_binary"])).resolve()
     source = Path(os.path.expanduser(runtime.get("source", str(cuda_binary.parents[2])))).resolve()
     build_dir, accelerator_flag = cmake_configuration(backend)
-    binary = source / build_dir / "bin/llama-server"
+    binary = native_server_binary(source, build_dir)
     revision = runtime["revision"]
     if not source.exists():
         if check_only:

--- a/tests/test_native_runtime_installer.py
+++ b/tests/test_native_runtime_installer.py
@@ -28,6 +28,15 @@ def test_native_installer_generates_backend_specific_cmake_configuration() -> No
     assert module.cmake_configuration("cpu") == ("build-cpu", "-DGGML_NATIVE=ON")
 
 
+def test_native_installer_resolves_visual_studio_release_executable(monkeypatch) -> None:
+    module = _module()
+    monkeypatch.setattr(module.os, "name", "nt")
+
+    assert module.native_server_binary(Path("runtime"), "build-vulkan") == Path(
+        "runtime/build-vulkan/bin/Release/llama-server.exe"
+    )
+
+
 def test_native_installer_excludes_separate_freetoken_candidate() -> None:
     module = _module()
     manifest = __import__("json").loads((ROOT / "references/native-runtimes.json").read_text())


### PR DESCRIPTION
## Summary
- Resolve Visual Studio CMake output as bin/Release/llama-server.exe on Windows.
- Keep the existing Unix executable path unchanged.
- Add a regression test for the Windows Vulkan runtime layout.

## Validation
- python -m py_compile scripts/install-native-runtimes
- Focused Windows path regression: passed.
- Full installer test module: blocked by an existing main-branch expectation that omits the now-default maple-llama.cpp runtime; unrelated to this change.

## Reproduction
On Windows 10 with Vulkan, CMake produced bin/Release/llama-server.exe while the installer searched for bin/llama-server.
