### PR TITLE
docs: explain remote Mac model servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,8 @@ Desktop: **Serve on Tailscale**. Same as `/turbofit serve`. Check with `/turbofi
 
 Public binds stay rejected. Loopback and verified tailnet addresses are the only plain-HTTP exceptions.
 
+For the split topology where Turbofit runs on a Mac and Hermes runs in a Proxmox LXC, see [`docs/remote-hermes-model-server.md`](docs/remote-hermes-model-server.md). It covers private Tailscale/LAN publication, connectivity checks from the LXC, named provider configuration, and selecting the remote provider from Hermes Desktop.
+
 ## Hermes configuration
 
 ```yaml

--- a/docs/remote-hermes-model-server.md
+++ b/docs/remote-hermes-model-server.md
@@ -1,0 +1,89 @@
+# Remote Mac model server with Hermes in a Proxmox LXC
+
+Turbofit can run on one machine while a Hermes Agent gateway runs on another. This is useful when the Mac has the Apple Silicon memory bandwidth and Metal acceleration, while the Hermes runtime, tools, files, sessions, and credentials live in a Proxmox LXC.
+
+```text
+Mac                                  Proxmox LXC
+Turbofit + local model server  <───  Hermes Agent + hermes serve
+                                     tools, files, sessions, state
+```
+
+The connection has two separate hops:
+
+1. Hermes Desktop on the Mac connects to `hermes serve` in the LXC.
+2. Hermes in the LXC connects to Turbofit's OpenAI-compatible `/v1` endpoint on the Mac.
+
+## 1. Publish Turbofit on the private network
+
+Install and configure Turbofit on the Mac as usual. The local provider gateway listens on `127.0.0.1:8091` by default. For a private cross-machine connection, use Tailscale Serve:
+
+```text
+/turbofit serve
+```
+
+This publishes the provider gateway on a private HTTPS URL such as:
+
+```text
+https://mac-name.example-tailnet.ts.net:9443/v1
+```
+
+Turbofit uses Tailscale Serve, not Funnel. Do not expose the provider gateway directly to the public internet.
+
+If you are using a trusted LAN instead of Tailscale, the model server or Turbofit gateway may use a private address such as `192.168.1.50`. Restrict the Mac firewall to the LXC or trusted LAN. Plain HTTP is intentionally accepted only for loopback, private-network, and Tailscale addresses; public endpoints must use HTTPS.
+
+## 2. Verify connectivity from the LXC
+
+Run this from inside the Proxmox LXC:
+
+```bash
+curl -fsS https://mac-name.example-tailnet.ts.net:9443/v1/models | jq .
+# Or, for a private LAN endpoint:
+curl -fsS http://192.168.1.50:8091/v1/models | jq .
+```
+
+If this fails, fix routing, Tailscale membership, firewall rules, or the Mac-side Turbofit service before changing Hermes configuration. `localhost` in the LXC refers to the LXC itself, not the Mac.
+
+## 3. Configure the remote Hermes profile
+
+The provider configuration belongs to the Hermes profile running in the LXC. Add the Mac endpoint under `providers:` and select it as the active model route:
+
+```yaml
+model:
+  provider: custom:mac-turbofit
+  default: auto
+
+providers:
+  mac-turbofit:
+    name: Mac Turbofit
+    api: https://mac-name.example-tailnet.ts.net:9443/v1
+    api_key: not-needed
+    transport: chat_completions
+    default_model: auto
+    models:
+      auto: {}
+      active:main: {}
+      active:aux: {}
+```
+
+For a LAN deployment, replace the `api` value with the Mac's private address and port. Keep the endpoint in the LXC's profile config; the Mac Desktop client's local Hermes config is a different machine and a different profile.
+
+Start a new Hermes session after changing the provider. In the LXC, `hermes model` can select the named **Mac Turbofit** provider. If the endpoint advertises multiple models, the picker can use the returned model inventory. The Hermes tools and filesystem still execute in the LXC.
+
+## 4. Select it from Hermes Desktop
+
+On the Mac:
+
+1. Open Hermes Desktop and select the remote Proxmox gateway under **Settings → Gateways**.
+2. Select the intended remote Hermes profile.
+3. Open the model picker.
+4. Choose **Mac Turbofit** and its model.
+
+The picker is scoped to the selected remote gateway/profile. Selecting the provider changes the remote Hermes profile; it does not start a second local Hermes backend or move tool execution to the Mac.
+
+## Security notes
+
+- Prefer Tailscale Serve for the provider URL.
+- Use HTTPS for public or otherwise untrusted networks.
+- Do not put credentials in fallback entries or checked-in files.
+- If the model server requires authentication, configure a `key_env` in the LXC's Hermes provider and store the secret in the LXC's `~/.hermes/.env`.
+- Keep Turbofit's provider gateway private; it is an inference endpoint, not a public web service.

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -83,6 +83,22 @@ def test_configure_hermes_registers_named_provider_and_primary_model() -> None:
     assert original["custom_providers"][-1]["name"] == "other"
 
 
+def test_remote_private_and_tailnet_provider_endpoints_are_normalized() -> None:
+    from plugin_tools import _validated_base_url
+
+    assert _validated_base_url("http://192.168.1.50:8091") == "http://192.168.1.50:8091/v1"
+    assert _validated_base_url("http://mac-name.example-tailnet.ts.net:8091/v1") == "http://mac-name.example-tailnet.ts.net:8091/v1"
+    assert _validated_base_url("https://mac-name.example.com:9443") == "https://mac-name.example.com:9443/v1"
+
+
+def test_public_plain_http_provider_endpoint_is_rejected() -> None:
+    import pytest
+    from plugin_tools import _validated_base_url
+
+    with pytest.raises(ValueError, match="loopback or a Tailscale address"):
+        _validated_base_url("http://model.example.com:8091")
+
+
 def test_configure_hermes_writes_matching_main_aux_context() -> None:
     from plugin_tools import configure_hermes
 


### PR DESCRIPTION
## Summary

- Document the supported split topology where Turbofit and the local model server run on a Mac while Hermes Agent runs in a Proxmox LXC.
- Explain the two network hops: Hermes Desktop → remote Hermes gateway, then Hermes in the LXC → Turbofit on the Mac.
- Show private Tailscale Serve and LAN endpoint setup, connectivity checks from the LXC, and the `localhost` pitfall.
- Document named provider configuration and selecting the remote Turbofit endpoint from the remote Hermes Desktop profile.
- Add regression coverage for private/Tailscale HTTPS endpoint normalization and rejection of public plain HTTP.

## Test plan

- `.venv/bin/python -m pytest -q tests/test_plugin.py` — 41 passed
- `.venv/bin/python -m py_compile plugin_tools.py product_ops.py dashboard/plugin_api.py`
- `node --check desktop/plugin.js`
- `git diff --check`
- `scripts/release-check` — reaches the existing repository-wide cross-platform test-isolation failure where a Windows test leaves `pathlib.WindowsPath` active on Linux; focused plugin tests and all changed-file syntax checks pass.

## Scope

Documentation and regression coverage only; no runtime behavior changes.
