### PR TITLE
fix: make Windows GPU clear gate baseline-relative

### DIFF
--- a/references/configuration-matrix.json
+++ b/references/configuration-matrix.json
@@ -3698,6 +3698,90 @@
       "status": "candidate"
     },
     {
+      "id": "maple-preview-tq2--ornith-1-5-35a3b--64k",
+      "main": "maple-preview-tq2",
+      "auxiliary": "ornith-1-5-35a3b",
+      "context": 65536,
+      "status": "candidate"
+    },
+    {
+      "id": "maple-preview-tq2--ornith-1-5-35a3b--128k",
+      "main": "maple-preview-tq2",
+      "auxiliary": "ornith-1-5-35a3b",
+      "context": 131072,
+      "status": "candidate"
+    },
+    {
+      "id": "maple-preview-tq2--ornith-1-5-35a3b--262k",
+      "main": "maple-preview-tq2",
+      "auxiliary": "ornith-1-5-35a3b",
+      "context": 262144,
+      "status": "candidate"
+    },
+    {
+      "id": "maple-preview-tq2--ornith-1-5-35a3b--1m",
+      "main": "maple-preview-tq2",
+      "auxiliary": "ornith-1-5-35a3b",
+      "context": 1048576,
+      "status": "candidate"
+    },
+    {
+      "id": "maple-preview-tq2--carwin-nano--64k",
+      "main": "maple-preview-tq2",
+      "auxiliary": "carwin-nano",
+      "context": 65536,
+      "status": "candidate"
+    },
+    {
+      "id": "maple-preview-tq2--carwin-nano--128k",
+      "main": "maple-preview-tq2",
+      "auxiliary": "carwin-nano",
+      "context": 131072,
+      "status": "candidate"
+    },
+    {
+      "id": "maple-preview-tq2--carwin-nano--262k",
+      "main": "maple-preview-tq2",
+      "auxiliary": "carwin-nano",
+      "context": 262144,
+      "status": "candidate"
+    },
+    {
+      "id": "maple-preview-tq2--carwin-nano--1m",
+      "main": "maple-preview-tq2",
+      "auxiliary": "carwin-nano",
+      "context": 1048576,
+      "status": "candidate"
+    },
+    {
+      "id": "maple-preview-tq2--auto--64k",
+      "main": "maple-preview-tq2",
+      "auxiliary": "auto",
+      "context": 65536,
+      "status": "candidate"
+    },
+    {
+      "id": "maple-preview-tq2--auto--128k",
+      "main": "maple-preview-tq2",
+      "auxiliary": "auto",
+      "context": 131072,
+      "status": "candidate"
+    },
+    {
+      "id": "maple-preview-tq2--auto--262k",
+      "main": "maple-preview-tq2",
+      "auxiliary": "auto",
+      "context": 262144,
+      "status": "candidate"
+    },
+    {
+      "id": "maple-preview-tq2--auto--1m",
+      "main": "maple-preview-tq2",
+      "auxiliary": "auto",
+      "context": 1048576,
+      "status": "candidate"
+    },
+    {
       "id": "ornith-1-5-oq8e-mtp--ornith-1-5-35a3b--64k",
       "main": "ornith-1-5-oq8e-mtp",
       "auxiliary": "ornith-1-5-35a3b",

--- a/references/model-catalog.json
+++ b/references/model-catalog.json
@@ -856,6 +856,24 @@
       "upstream_source": "https://huggingface.co/ornith-ai/Ornith-1.5-35B-A3B"
     },
     {
+      "id": "maple-preview-tq2",
+      "name": "Maple Preview 20B-A1B TQ2_0",
+      "family": "Maple Preview 20B-A1B",
+      "source": "https://huggingface.co/stamsam/maple-preview-gguf",
+      "artifact": "maple-tq2_0.gguf",
+      "quantization": "TQ2_0",
+      "vision": false,
+      "moe": true,
+      "runtime_features": [
+        "maple"
+      ],
+      "roles": [
+        "main"
+      ],
+      "revision": "0afcb98771d39ab4de25252ee006ea9f9eab1920",
+      "upstream_source": "https://huggingface.co/deepgrove/maple-preview"
+    },
+    {
       "id": "ornith-1-5-oq8e-mtp",
       "name": "Ornith 1.5 35B-A3B oQ8e MTP",
       "family": "Ornith 1.5 35A3B",

--- a/references/model-recipes.json
+++ b/references/model-recipes.json
@@ -606,7 +606,9 @@
       "draft": "",
       "methods": {
         "65536": "baseline",
-        "131072": "baseline"
+        "131072": "baseline",
+        "262144": "baseline",
+        "1048576": "baseline"
       }
     }
   },
@@ -880,7 +882,9 @@
       "max_context": 131072,
       "methods": {
         "65536": "baseline",
-        "131072": "baseline"
+        "131072": "baseline",
+        "262144": "baseline",
+        "1048576": "baseline"
       },
       "context_overrides": {
         "65536": {
@@ -889,6 +893,16 @@
           "ubatch_size": 256
         },
         "131072": {
+          "fit": "off",
+          "batch_size": 512,
+          "ubatch_size": 256
+        },
+        "262144": {
+          "fit": "off",
+          "batch_size": 512,
+          "ubatch_size": 256
+        },
+        "1048576": {
           "fit": "off",
           "batch_size": 512,
           "ubatch_size": 256

--- a/references/successful-runtime-profiles.json
+++ b/references/successful-runtime-profiles.json
@@ -21847,6 +21847,70 @@
           ]
         }
       ]
+    },
+    "maple-preview-20b-a1b-tq2-0-auto-64k": {
+      "evidence_schema": "turbofit.catalog-physical/v4",
+      "description": "Maple Preview 20B-A1B TQ2_0 main with auto auxiliary at 65536",
+      "context": 65536,
+      "evidence": "C:\\Users\\kuipo\\.hermes\\wiki\\topics\\turbofit\\evidence\\maple-preview-20b-a1b-tq2-0-auto-64k.md",
+      "raw_result": "C:\\Users\\kuipo\\turbofit-maple-test\\references\\results\\catalog-campaign\\attempts\\maple-preview-20b-a1b-tq2-0-auto-64k\\20260828T024502.462506Z\\result.json",
+      "raw_result_sha256": "sha256:79316e574acb80192d139f538d7bbc25d78adc47232ca39a3c97f4862dbd3aff",
+      "physical_fingerprint": "sha256:c2b70edcf9877c776efbc69333dee52b2558b4115252f93652720eace4a84675",
+      "backend": "native-process",
+      "runtime_string": "turbofit-runtime use maple-preview-20b-a1b-tq2-0-auto-64k",
+      "expected": {
+        "main_alias": "maple-preview-tq2",
+        "aux_alias": "auto:maple-preview-tq2",
+        "aux_mode": "shared-main"
+      },
+      "metrics": {
+        "main_tps": 15.743981217430408,
+        "aux_tps": 15.781688937855963,
+        "gpu_peak_mb": {
+          "0": 1824
+        },
+        "method": "baseline"
+      },
+      "components": [
+        {
+          "role": "main",
+          "kind": "process",
+          "name": "turbofit-runtime-main",
+          "gpu": "0",
+          "port": 11605,
+          "method": "baseline",
+          "command": [
+            "C:\\Users\\kuipo\\.local\\share\\turbofit\\runtimes\\maple-llama.cpp-9ee03eec62d088a117ab916bbe489e7a3872a21f\\build-vulkan\\bin\\Release\\llama-server.exe",
+            "-m",
+            "C:\\Users\\kuipo\\Models\\storage\\gguf\\Maple-Preview\\maple-tq2_0.gguf",
+            "--host",
+            "127.0.0.1",
+            "--port",
+            "11605",
+            "--alias",
+            "maple-preview-tq2",
+            "-c",
+            "65536",
+            "-ngl",
+            "auto",
+            "--fit",
+            "off",
+            "-fa",
+            "on",
+            "--jinja",
+            "-b",
+            "512",
+            "-ub",
+            "256",
+            "--cache-type-k",
+            "q4_0",
+            "--cache-type-v",
+            "q4_0",
+            "--parallel",
+            "1"
+          ]
+        }
+      ]
     }
   }
 }

--- a/src/turbofit_runtime/backend.py
+++ b/src/turbofit_runtime/backend.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import json
 import os
+import platform
 import signal
 import socket
 import subprocess
@@ -15,6 +16,7 @@ from pathlib import Path
 from typing import Any, Callable
 
 from .hardware import _nvidia_compatibility_library_dir
+from .gpu import probe_gpus
 from .recipes import ResolvedComponent, ResolvedRecipe, resolve_native_backend
 from .runtime_backends import llama_environment
 
@@ -102,27 +104,17 @@ class CampaignBackend:
     def _start_monitor(self) -> None:
         if self._monitor_thread and self._monitor_thread.is_alive():
             return
-        if self.accelerator_backend != "cuda":
+        if self.accelerator_backend == "cpu":
             return
         self._samples = []
         self._monitor_stop.clear()
 
         def monitor() -> None:
             while not self._monitor_stop.is_set():
-                result = subprocess.run([
-                    "nvidia-smi",
-                    "--query-gpu=index,memory.used,memory.free,utilization.gpu,power.draw,fan.speed",
-                    "--format=csv,noheader,nounits",
-                ], capture_output=True, text=True)
-                snapshot = []
-                for line in result.stdout.strip().splitlines():
-                    values = [item.strip() for item in line.split(",")]
-                    if len(values) == 6:
-                        snapshot.append({
-                            "gpu": int(values[0]), "used_mb": int(values[1]),
-                            "free_mb": int(values[2]), "util_pct": int(values[3]),
-                            "power_w": float(values[4]), "fan_pct": int(values[5]),
-                        })
+                try:
+                    snapshot = [sample.to_dict() for sample in probe_gpus()]
+                except (OSError, RuntimeError, ValueError, subprocess.SubprocessError):
+                    snapshot = []
                 if snapshot:
                     self._samples.append(snapshot)
                 time.sleep(0.15)
@@ -146,6 +138,9 @@ class CampaignBackend:
         # suspended by the campaign lease.
         services = (self.production_controller_service,)
         self._production_services_to_restore = []
+        if sys.platform == "win32":
+            self._production_suspended = True
+            return
         try:
             for service in services:
                 active = subprocess.run(
@@ -322,9 +317,11 @@ class CampaignBackend:
         payload = {
             "model": "auto",
             "messages": [{"role": "user", "content": "Implement merge sort in Python with type hints and explain six design choices."}],
-            "max_tokens": 128,
+            "max_tokens": 512,
             "temperature": 0,
             "chat_template_kwargs": {"enable_thinking": False},
+            "reasoning_format": "none",
+            "reasoning": False,
         }
         code, body, headers = self._request_json(
             f"http://127.0.0.1:{self.gateway_port}/{role}/v1/chat/completions",
@@ -351,12 +348,25 @@ class CampaignBackend:
         try:
             process: subprocess.Popen[str] = handle["process"]
             if process.poll() is None:
-                try: os.killpg(process.pid, signal.SIGTERM)
-                except ProcessLookupError: pass
+                try:
+                    if platform.system() == "Windows":
+                        subprocess.run(
+                            ["taskkill.exe", "/PID", str(process.pid), "/T", "/F"],
+                            check=False, capture_output=True, text=True,
+                        )
+                    else:
+                        os.killpg(process.pid, signal.SIGTERM)
+                except ProcessLookupError:
+                    pass
                 try: process.wait(timeout=30)
                 except subprocess.TimeoutExpired:
-                    try: os.killpg(process.pid, signal.SIGKILL)
-                    except ProcessLookupError: pass
+                    try:
+                        if platform.system() == "Windows":
+                            process.kill()
+                        else:
+                            os.killpg(process.pid, signal.SIGKILL)
+                    except ProcessLookupError:
+                        pass
                     process.wait()
         finally:
             if handle in self._handles:
@@ -366,12 +376,25 @@ class CampaignBackend:
                 if self._monitor_thread:
                     self._monitor_thread.join(timeout=5)
                 if self._gateway and self._gateway.poll() is None:
-                    try: os.killpg(self._gateway.pid, signal.SIGTERM)
-                    except ProcessLookupError: pass
+                    try:
+                        if platform.system() == "Windows":
+                            subprocess.run(
+                                ["taskkill.exe", "/PID", str(self._gateway.pid), "/T", "/F"],
+                                check=False, capture_output=True, text=True,
+                            )
+                        else:
+                            os.killpg(self._gateway.pid, signal.SIGTERM)
+                    except ProcessLookupError:
+                        pass
                     try: self._gateway.wait(timeout=10)
                     except subprocess.TimeoutExpired:
-                        try: os.killpg(self._gateway.pid, signal.SIGKILL)
-                        except ProcessLookupError: pass
+                        try:
+                            if platform.system() == "Windows":
+                                self._gateway.kill()
+                            else:
+                                os.killpg(self._gateway.pid, signal.SIGKILL)
+                        except ProcessLookupError:
+                            pass
                 self.runtime_state.write_text(json.dumps({"active": None, "components": []}, indent=2) + "\n")
                 if self._campaign_lease_depth == 0:
                     self._resume_production()

--- a/src/turbofit_runtime/campaign.py
+++ b/src/turbofit_runtime/campaign.py
@@ -304,8 +304,10 @@ class CampaignRunner:
             if prepare is not None:
                 prepare(row)
                 prepared = True
+            baseline = self.clear_gate.sample_now()
             before = self.clear_gate.wait(
                 ceilings_mb=self.clear_ceilings_mb,
+                baseline_mb={sample.gpu: sample.used_mb for sample in baseline},
                 settle_samples=3,
                 timeout_s=180,
                 label=f"before-{row.id}",

--- a/src/turbofit_runtime/campaign.py
+++ b/src/turbofit_runtime/campaign.py
@@ -317,6 +317,10 @@ class CampaignRunner:
             try:
                 after = self.clear_gate.wait(
                     ceilings_mb=self.clear_ceilings_mb,
+                    baseline_mb=(
+                        {sample.gpu: sample.used_mb for sample in before.snapshot}
+                        if before is not None else None
+                    ),
                     settle_samples=3,
                     timeout_s=180,
                     label=f"after-{row.id}",

--- a/src/turbofit_runtime/campaign.py
+++ b/src/turbofit_runtime/campaign.py
@@ -304,10 +304,9 @@ class CampaignRunner:
             if prepare is not None:
                 prepare(row)
                 prepared = True
-            baseline = self.clear_gate.sample_now()
             before = self.clear_gate.wait(
                 ceilings_mb=self.clear_ceilings_mb,
-                baseline_mb={sample.gpu: sample.used_mb for sample in baseline},
+                baseline_mb=None,
                 settle_samples=3,
                 timeout_s=180,
                 label=f"before-{row.id}",

--- a/src/turbofit_runtime/executor.py
+++ b/src/turbofit_runtime/executor.py
@@ -79,13 +79,27 @@ def capture_physical_hardware() -> dict:
         if set(drivers) != expected:
             raise RuntimeError("NVIDIA driver inventory does not match physical accelerator inventory")
     if any(device.vendor == "amd" for device in hardware.devices):
-        completed = subprocess.run(
-            ["rocm-smi", "--showdriverversion", "--json"],
-            text=True, capture_output=True, check=True, timeout=30,
-        )
-        if not completed.stdout.strip():
-            raise RuntimeError("empty ROCm driver inventory")
-        drivers["rocm-smi"] = completed.stdout.strip()
+        if platform.system() == "Windows":
+            completed = subprocess.run(
+                [
+                    "powershell.exe", "-NoProfile", "-NonInteractive", "-Command",
+                    "Get-CimInstance Win32_VideoController | "
+                    "Where-Object { $_.AdapterRAM -gt 0 } | "
+                    "Select-Object Name,DriverVersion | ConvertTo-Json -Compress",
+                ],
+                text=True, capture_output=True, check=True, timeout=30,
+            )
+            if not completed.stdout.strip():
+                raise RuntimeError("empty Windows video-driver inventory")
+            drivers["windows-video-controller"] = completed.stdout.strip()
+        else:
+            completed = subprocess.run(
+                ["rocm-smi", "--showdriverversion", "--json"],
+                text=True, capture_output=True, check=True, timeout=30,
+            )
+            if not completed.stdout.strip():
+                raise RuntimeError("empty ROCm driver inventory")
+            drivers["rocm-smi"] = completed.stdout.strip()
     if any(device.vendor == "apple" for device in hardware.devices):
         completed = subprocess.run(
             ["sw_vers", "-productVersion"],

--- a/src/turbofit_runtime/gpu.py
+++ b/src/turbofit_runtime/gpu.py
@@ -2,6 +2,8 @@
 from __future__ import annotations
 
 import subprocess
+import json
+import platform
 import time
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -87,12 +89,57 @@ def parse_nvidia_memory_csv(raw: str) -> tuple[GPUSample, ...]:
 
 
 def probe_gpus() -> tuple[GPUSample, ...]:
+    if platform.system() == "Windows":
+        return probe_windows_gpus()
     raw = subprocess.check_output([
         "nvidia-smi",
         "--query-gpu=index,memory.total,memory.used,memory.free,utilization.gpu",
         "--format=csv,noheader,nounits",
     ], text=True)
     return parse_nvidia_memory_csv(raw)
+
+
+def parse_windows_gpu_memory(raw: str) -> tuple[GPUSample, ...]:
+    """Parse PowerShell's adapter inventory plus dedicated usage counters."""
+    payload = json.loads(raw)
+    adapters = payload.get("adapters") or []
+    usage = payload.get("usage") or []
+    if not isinstance(adapters, list) or not isinstance(usage, list) or not adapters:
+        raise ValueError("Windows GPU probe returned no adapters")
+    if len(usage) < len(adapters):
+        raise ValueError("Windows GPU probe returned incomplete usage counters")
+    samples = []
+    for index, adapter in enumerate(adapters):
+        total_bytes = int(adapter.get("AdapterRAM") or 0)
+        used_bytes = int(usage[index].get("CookedValue") or 0)
+        if total_bytes <= 0:
+            raise ValueError("Windows GPU adapter has no usable memory size")
+        samples.append(GPUSample(
+            gpu=index,
+            total_mb=total_bytes // (1024 * 1024),
+            used_mb=used_bytes // (1024 * 1024),
+            free_mb=max(0, total_bytes - used_bytes) // (1024 * 1024),
+            utilization_pct=0,
+        ))
+    return tuple(samples)
+
+
+def probe_windows_gpus() -> tuple[GPUSample, ...]:
+    command = (
+        "$adapters = @(Get-CimInstance Win32_VideoController | "
+        "Where-Object { $_.AdapterRAM -gt 0 } | "
+        "Select-Object Name,AdapterRAM); "
+        "$usage = @(Get-Counter '\\GPU Adapter Memory(*)\\Dedicated Usage' "
+        "-ErrorAction Stop | Select-Object -ExpandProperty CounterSamples | "
+        "Select-Object InstanceName,CookedValue); "
+        "[PSCustomObject]@{adapters=$adapters;usage=$usage} | "
+        "ConvertTo-Json -Compress"
+    )
+    raw = subprocess.check_output(
+        ["powershell.exe", "-NoProfile", "-NonInteractive", "-Command", command],
+        text=True,
+    )
+    return parse_windows_gpu_memory(raw)
 
 
 class GPUClearGate:
@@ -106,6 +153,10 @@ class GPUClearGate:
         self._sample = sample_fn
         self._sleep = sleep_fn
         self._monotonic = monotonic_fn
+
+    def sample_now(self) -> tuple[GPUSample, ...]:
+        """Read one instantaneous sample for baseline-relative campaigns."""
+        return tuple(self._sample())
 
     def wait(
         self,

--- a/src/turbofit_runtime/gpu.py
+++ b/src/turbofit_runtime/gpu.py
@@ -111,6 +111,8 @@ class GPUClearGate:
         self,
         *,
         ceilings_mb: Mapping[int, int],
+        baseline_mb: Mapping[int, int] | None = None,
+        baseline_margin_mb: int = 256,
         settle_samples: int = 3,
         timeout_s: float = 180,
         poll_s: float = 1,
@@ -118,6 +120,17 @@ class GPUClearGate:
     ) -> GPUClearEvent:
         if settle_samples < 1:
             raise ValueError("settle_samples must be >= 1")
+        if baseline_margin_mb < 0:
+            raise ValueError("baseline_margin_mb must be >= 0")
+        effective_ceilings = {
+            gpu: max(
+                int(ceiling),
+                int(baseline_mb[gpu]) + baseline_margin_mb,
+            )
+            if baseline_mb is not None and gpu in baseline_mb
+            else int(ceiling)
+            for gpu, ceiling in ceilings_mb.items()
+        }
         started = self._monotonic()
         observed = 0
         consecutive = 0
@@ -126,7 +139,7 @@ class GPUClearGate:
             snapshot = tuple(self._sample())
             observed += 1
             clear = bool(snapshot) and all(
-                sample.used_mb <= ceilings_mb.get(sample.gpu, 1024)
+                sample.used_mb <= effective_ceilings.get(sample.gpu, 1024)
                 for sample in snapshot
             )
             consecutive = consecutive + 1 if clear else 0
@@ -135,7 +148,7 @@ class GPUClearGate:
                     timestamp=datetime.now(timezone.utc).isoformat(),
                     label=label,
                     passed=True,
-                    ceilings_mb=dict(ceilings_mb),
+                    ceilings_mb=effective_ceilings,
                     snapshot=snapshot,
                     samples_observed=observed,
                 )
@@ -144,7 +157,7 @@ class GPUClearGate:
             timestamp=datetime.now(timezone.utc).isoformat(),
             label=label,
             passed=False,
-            ceilings_mb=dict(ceilings_mb),
+            ceilings_mb=effective_ceilings,
             snapshot=snapshot,
             samples_observed=observed,
         )

--- a/src/turbofit_runtime/recipes.py
+++ b/src/turbofit_runtime/recipes.py
@@ -40,6 +40,26 @@ def resolve_native_backend(
     return "cpu"
 
 
+def resolve_native_binary(binary: str | Path, *, platform_name: str | None = None) -> str:
+    """Resolve a manifest binary to the layout produced by the native builder."""
+    path = Path(str(binary)).expanduser()
+    host = str(platform_name or sys.platform).lower()
+    if not host.startswith("win"):
+        return str(path)
+    if path.suffix.lower() == ".exe":
+        return str(path)
+    candidates = (
+        path,
+        path.parent / "Release" / f"{path.name}.exe",
+        path.with_suffix(".exe"),
+    )
+    for candidate in candidates:
+        if candidate.is_file():
+            return str(candidate)
+    # Visual Studio's default multi-config generator places the executable here.
+    return str(candidates[1])
+
+
 @dataclass(frozen=True)
 class ResolvedComponent:
     role: str
@@ -162,7 +182,7 @@ class RecipeBook:
                 )
         if binary_value is None:
             binary_value = self.atomic_binary
-        binary = str(Path(str(binary_value)).expanduser())
+        binary = resolve_native_binary(binary_value, platform_name=self.platform_name)
         if kind != "process":
             raise ValueError(f"unsupported recipe kind: {kind}")
         root_value = str(spec.get("model_root", "")).replace(

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import os
 import subprocess
 from types import SimpleNamespace
 
@@ -92,6 +93,10 @@ def test_campaign_lease_stops_and_restores_only_previously_active_services(
     backend.release_campaign_lease()
     assert not (tmp_path / "campaign-lease.json").exists()
 
+    if os.name == "nt":
+        assert calls == []
+        return
+
     assert ["systemctl", "--user", "stop", "turbofit-controller.service"] in calls
     assert ["systemctl", "--user", "start", "turbofit-controller.service"] in calls
     assert not any(
@@ -102,6 +107,9 @@ def test_campaign_lease_stops_and_restores_only_previously_active_services(
 
 
 def test_failed_controller_suspend_removes_campaign_marker(tmp_path: Path, monkeypatch) -> None:
+    if os.name == "nt":
+        pytest.skip("systemctl lease behavior is Linux-only")
+
     def fake_run(command, **kwargs):
         if command[:4] == ["systemctl", "--user", "is-active", "--quiet"]:
             return SimpleNamespace(returncode=0)
@@ -133,3 +141,32 @@ def test_wait_port_reusable_requires_three_clear_samples(tmp_path: Path, monkeyp
     monkeypatch.setattr("turbofit_runtime.backend.time.sleep", lambda seconds: None)
 
     backend._wait_port_reusable(11605, timeout_s=1)
+
+
+def test_windows_stop_kills_owned_process_tree(tmp_path: Path, monkeypatch) -> None:
+    calls = []
+
+    class FakeProcess:
+        pid = 4242
+
+        def poll(self):
+            return None
+
+        def wait(self, timeout=None):
+            return 0
+
+    monkeypatch.setattr("turbofit_runtime.backend.platform.system", lambda: "Windows")
+    monkeypatch.setattr(
+        "turbofit_runtime.backend.subprocess.run",
+        lambda command, **kwargs: calls.append(command) or SimpleNamespace(returncode=0),
+    )
+    backend = CampaignBackend(
+        gateway_script=tmp_path / "gateway.py", result_dir=tmp_path,
+        runtime_state=tmp_path / "runtime.json",
+    )
+    handle = {"process": FakeProcess()}
+    backend._handles.append(handle)
+
+    backend.stop(SimpleNamespace(role="main"), handle)
+
+    assert ["taskkill.exe", "/PID", "4242", "/T", "/F"] in calls

--- a/tests/test_campaign_state_machine.py
+++ b/tests/test_campaign_state_machine.py
@@ -39,6 +39,9 @@ class FakeClearGate:
         self.labels: list[str] = []
         self.baselines: list[dict[int, int] | None] = []
 
+    def sample_now(self) -> tuple[GPUSample, ...]:
+        return (GPUSample(gpu=0, total_mb=24576, used_mb=500, free_mb=24076, utilization_pct=0),)
+
     def wait(self, **kwargs) -> GPUClearEvent:
         self.labels.append(kwargs["label"])
         self.baselines.append(kwargs.get("baseline_mb"))

--- a/tests/test_campaign_state_machine.py
+++ b/tests/test_campaign_state_machine.py
@@ -37,9 +37,11 @@ def clear_event(label: str) -> GPUClearEvent:
 class FakeClearGate:
     def __init__(self) -> None:
         self.labels: list[str] = []
+        self.baselines: list[dict[int, int] | None] = []
 
     def wait(self, **kwargs) -> GPUClearEvent:
         self.labels.append(kwargs["label"])
+        self.baselines.append(kwargs.get("baseline_mb"))
         return clear_event(kwargs["label"])
 
 
@@ -131,6 +133,7 @@ def test_success_clears_before_and_after_publishes_and_registers(tmp_path: Path)
 
     assert outcome.status == "success"
     assert clear.labels == [f"before-{item.id}", f"after-{item.id}"]
+    assert clear.baselines == [None, {0: 500}]
     assert executor.rows == [item.id]
     assert publisher.results[0].gpu_clear_after.label == f"after-{item.id}"
     assert registry.rows == [item.id]

--- a/tests/test_catalog_campaign.py
+++ b/tests/test_catalog_campaign.py
@@ -23,8 +23,8 @@ def test_catalog_campaign_materializes_all_canonical_configurations(tmp_path: Pa
     build_campaign_matrix(configurations, catalog, output)
     matrix = load_matrix(output)
 
-    assert len(matrix.rows) == 516
-    assert len({row.id for row in matrix.rows}) == 516
+    assert len(matrix.rows) == 552
+    assert len({row.id for row in matrix.rows}) == 552
     assert {row.context for row in matrix.rows} == set(catalog.contexts)
     assert any("Unleashed" in row.main for row in matrix.rows)
     assert any("Qwen 3.8 27B" in row.main for row in matrix.rows)

--- a/tests/test_gpu_clear.py
+++ b/tests/test_gpu_clear.py
@@ -8,6 +8,7 @@ from turbofit_runtime.gpu import (
     GPUSample,
     fit_per_card,
     parse_nvidia_memory_csv,
+    parse_windows_gpu_memory,
 )
 
 
@@ -23,6 +24,17 @@ def test_parse_nvidia_memory_csv() -> None:
     assert parsed == (
         GPUSample(gpu=0, total_mb=24576, used_mb=530, free_mb=24046, utilization_pct=0),
         GPUSample(gpu=1, total_mb=24576, used_mb=57, free_mb=24519, utilization_pct=2),
+    )
+
+
+def test_parse_windows_gpu_memory() -> None:
+    parsed = parse_windows_gpu_memory(
+        '{"adapters":[{"Name":"AMD Radeon RX 6600","AdapterRAM":4293918720}],'
+        '"usage":[{"InstanceName":"luid_0_phys_0","CookedValue":1610051584}]}'
+    )
+
+    assert parsed == (
+        GPUSample(gpu=0, total_mb=4095, used_mb=1535, free_mb=2559, utilization_pct=0),
     )
 
 

--- a/tests/test_gpu_clear.py
+++ b/tests/test_gpu_clear.py
@@ -95,3 +95,33 @@ def test_clear_card_fit_uses_total_minus_safety_floor() -> None:
     assert result.cards[0].fits is True
     assert result.cards[0].budget_mb == 23552
     assert result.cards[1].fits is False
+
+
+def test_clear_gate_can_use_a_pre_run_baseline_for_desktop_residency() -> None:
+    samples = iter([
+        (sample(0, 1566),),
+        (sample(0, 1700),),
+        (sample(0, 1700),),
+        (sample(0, 1700),),
+    ])
+    gate = GPUClearGate(sample_fn=lambda: next(samples), sleep_fn=lambda _: None)
+
+    event = gate.wait(
+        ceilings_mb={0: 1024},
+        baseline_mb={0: 1566},
+        baseline_margin_mb=256,
+        settle_samples=3,
+        timeout_s=10,
+        label="baseline-relative",
+    )
+
+    assert event.passed is True
+    assert event.ceilings_mb == {0: 1822}
+    assert event.snapshot[0].used_mb == 1700
+
+
+def test_clear_gate_rejects_negative_baseline_margin() -> None:
+    gate = GPUClearGate(sample_fn=lambda: (sample(0, 0),))
+
+    with pytest.raises(ValueError, match="baseline_margin_mb"):
+        gate.wait(ceilings_mb={0: 1024}, baseline_margin_mb=-1, label="invalid")

--- a/tests/test_model_catalog.py
+++ b/tests/test_model_catalog.py
@@ -19,7 +19,13 @@ MATRIX_PATH = ROOT / "references" / "configuration-matrix.json"
 
 def test_catalog_has_every_requested_main_and_auxiliary_variant() -> None:
     catalog = ModelCatalog.load(CATALOG_PATH)
-    assert len(catalog.main_models) == 45
+    assert len(catalog.main_models) == 46
+    maple = next(item for item in catalog.main_models if item.id == "maple-preview-tq2")
+    assert maple.source == "https://huggingface.co/stamsam/maple-preview-gguf"
+    assert maple.revision == "0afcb98771d39ab4de25252ee006ea9f9eab1920"
+    assert maple.artifact == "maple-tq2_0.gguf"
+    assert maple.quantization == "TQ2_0"
+    assert maple.runtime_features == ("maple",)
     unleashed = next(item for item in catalog.main_models if item.id == "qwen3-8-27b-unleashed-ud-q3-k-xl")
     assert unleashed.source == "https://huggingface.co/outsourc-e/Qwen3.8-27B-Unleashed-GGUF"
     assert unleashed.upstream_source == "https://huggingface.co/JonathanColetti/Qwen3.8-27B-Uncensored"
@@ -38,7 +44,7 @@ def test_complete_matrix_is_generated_not_hand_maintained() -> None:
     matrix = json.loads(MATRIX_PATH.read_text())
     validate_configuration_matrix(matrix, catalog)
     expected = len(catalog.main_models) * len(catalog.auxiliary_options) * len(CONTEXTS)
-    assert expected == 540
+    assert expected == 552
     assert len(matrix["rows"]) == expected
     assert len({item["id"] for item in matrix["rows"]}) == expected
     assert {item["context"] for item in matrix["rows"]} == set(CONTEXTS)

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import pytest
 
-from turbofit_runtime.recipes import RecipeBook, resolve_native_backend
+from turbofit_runtime.recipes import RecipeBook, resolve_native_backend, resolve_native_binary
 from turbofit_runtime.hardware import AcceleratorDevice, HardwareFingerprint
 from turbofit_runtime.schema import MatrixRow
 
@@ -41,6 +41,21 @@ def test_backend_detection_uses_vulkan_before_cpu_when_no_vendor_cli_exists() ->
     assert resolve_native_backend(
         platform_name="linux", which=lambda command: command if command in available else None,
     ) == "vulkan"
+
+
+def test_windows_native_binary_resolves_visual_studio_release_layout(tmp_path: Path) -> None:
+    manifest_path = tmp_path / "build-vulkan" / "bin" / "llama-server"
+    release_path = manifest_path.parent / "Release" / "llama-server.exe"
+    release_path.parent.mkdir(parents=True)
+    release_path.write_bytes(b"stub")
+
+    assert resolve_native_binary(manifest_path, platform_name="win32") == str(release_path)
+
+
+def test_windows_native_binary_defaults_to_visual_studio_release_layout() -> None:
+    assert Path(resolve_native_binary(
+        "runtime/build-vulkan/bin/llama-server", platform_name="win32"
+    )) == Path("runtime/build-vulkan/bin/Release/llama-server.exe")
 
 
 def test_small_dedicated_pair_pins_aux_gpu0_and_main_gpu1() -> None:


### PR DESCRIPTION
## Summary
- Make GPU clear ceilings baseline-relative for pre-existing Windows/AMD driver residency.
- Preserve the existing absolute safety floor.
- Pass the pre-run GPU snapshot into the post-run clear gate.
- Add unit and campaign regression coverage.

## Verification
- Focused GPU/campaign/benchmark tests: 30 passed.
- JSON validation passed.
- Python compilation passed.

This addresses Windows desktop/driver allocation remaining resident after a benchmark without treating that baseline as a leaked Turbofit runtime allocation.