### PR TITLE
fix: honor per-model supported contexts

### DIFF
--- a/references/configuration-matrix.json
+++ b/references/configuration-matrix.json
@@ -3712,20 +3712,6 @@
       "status": "candidate"
     },
     {
-      "id": "maple-preview-tq2--ornith-1-5-35a3b--262k",
-      "main": "maple-preview-tq2",
-      "auxiliary": "ornith-1-5-35a3b",
-      "context": 262144,
-      "status": "candidate"
-    },
-    {
-      "id": "maple-preview-tq2--ornith-1-5-35a3b--1m",
-      "main": "maple-preview-tq2",
-      "auxiliary": "ornith-1-5-35a3b",
-      "context": 1048576,
-      "status": "candidate"
-    },
-    {
       "id": "maple-preview-tq2--carwin-nano--64k",
       "main": "maple-preview-tq2",
       "auxiliary": "carwin-nano",
@@ -3740,20 +3726,6 @@
       "status": "candidate"
     },
     {
-      "id": "maple-preview-tq2--carwin-nano--262k",
-      "main": "maple-preview-tq2",
-      "auxiliary": "carwin-nano",
-      "context": 262144,
-      "status": "candidate"
-    },
-    {
-      "id": "maple-preview-tq2--carwin-nano--1m",
-      "main": "maple-preview-tq2",
-      "auxiliary": "carwin-nano",
-      "context": 1048576,
-      "status": "candidate"
-    },
-    {
       "id": "maple-preview-tq2--auto--64k",
       "main": "maple-preview-tq2",
       "auxiliary": "auto",
@@ -3765,20 +3737,6 @@
       "main": "maple-preview-tq2",
       "auxiliary": "auto",
       "context": 131072,
-      "status": "candidate"
-    },
-    {
-      "id": "maple-preview-tq2--auto--262k",
-      "main": "maple-preview-tq2",
-      "auxiliary": "auto",
-      "context": 262144,
-      "status": "candidate"
-    },
-    {
-      "id": "maple-preview-tq2--auto--1m",
-      "main": "maple-preview-tq2",
-      "auxiliary": "auto",
-      "context": 1048576,
       "status": "candidate"
     },
     {

--- a/references/model-catalog.json
+++ b/references/model-catalog.json
@@ -870,6 +870,10 @@
       "roles": [
         "main"
       ],
+      "supported_contexts": [
+        65536,
+        131072
+      ],
       "revision": "0afcb98771d39ab4de25252ee006ea9f9eab1920",
       "upstream_source": "https://huggingface.co/deepgrove/maple-preview"
     },

--- a/src/turbofit_runtime/model_catalog.py
+++ b/src/turbofit_runtime/model_catalog.py
@@ -28,6 +28,7 @@ class ModelVariant:
     roles: tuple[str, ...]
     upstream_source: str | None = None
     upstream_revision: str | None = None
+    supported_contexts: tuple[int, ...] = CONTEXTS
 
     @classmethod
     def from_mapping(cls, value: Mapping[str, Any]) -> "ModelVariant":
@@ -35,7 +36,7 @@ class ModelVariant:
             "id", "name", "family", "source", "revision", "artifact", "quantization",
             "vision", "moe", "runtime_features", "roles",
         }
-        optional = {"upstream_source", "upstream_revision"}
+        optional = {"upstream_source", "upstream_revision", "supported_contexts"}
         if not required <= set(value) or set(value) - required - optional:
             raise ValueError("model variant fields do not match catalog schema")
         item = cls(
@@ -52,6 +53,7 @@ class ModelVariant:
             roles=tuple(value["roles"]),
             upstream_source=str(value["upstream_source"]) if value.get("upstream_source") else None,
             upstream_revision=str(value["upstream_revision"]) if value.get("upstream_revision") else None,
+            supported_contexts=tuple(value.get("supported_contexts", CONTEXTS)),
         )
         item.validate()
         return item
@@ -78,6 +80,8 @@ class ModelVariant:
             raise ValueError(f"model {self.id} has invalid roles")
         if len(self.runtime_features) != len(set(self.runtime_features)):
             raise ValueError(f"model {self.id} repeats a runtime feature")
+        if not self.supported_contexts or not set(self.supported_contexts) <= set(CONTEXTS):
+            raise ValueError(f"model {self.id} has invalid supported contexts")
 
 
 @dataclass(frozen=True)
@@ -129,7 +133,7 @@ def build_configuration_matrix(catalog: ModelCatalog) -> dict[str, Any]:
     rows = []
     for main in catalog.main_models:
         for aux in catalog.auxiliary_options:
-            for context in catalog.contexts:
+            for context in main.supported_contexts:
                 rows.append({
                     "id": f"{main.id}--{aux}--{_context_slug(context)}",
                     "main": main.id,

--- a/tests/test_catalog_campaign.py
+++ b/tests/test_catalog_campaign.py
@@ -23,8 +23,8 @@ def test_catalog_campaign_materializes_all_canonical_configurations(tmp_path: Pa
     build_campaign_matrix(configurations, catalog, output)
     matrix = load_matrix(output)
 
-    assert len(matrix.rows) == 552
-    assert len({row.id for row in matrix.rows}) == 552
+    assert len(matrix.rows) == 546
+    assert len({row.id for row in matrix.rows}) == 546
     assert {row.context for row in matrix.rows} == set(catalog.contexts)
     assert any("Unleashed" in row.main for row in matrix.rows)
     assert any("Qwen 3.8 27B" in row.main for row in matrix.rows)

--- a/tests/test_model_catalog.py
+++ b/tests/test_model_catalog.py
@@ -26,6 +26,7 @@ def test_catalog_has_every_requested_main_and_auxiliary_variant() -> None:
     assert maple.artifact == "maple-tq2_0.gguf"
     assert maple.quantization == "TQ2_0"
     assert maple.runtime_features == ("maple",)
+    assert maple.supported_contexts == (65536, 131072)
     unleashed = next(item for item in catalog.main_models if item.id == "qwen3-8-27b-unleashed-ud-q3-k-xl")
     assert unleashed.source == "https://huggingface.co/outsourc-e/Qwen3.8-27B-Unleashed-GGUF"
     assert unleashed.upstream_source == "https://huggingface.co/JonathanColetti/Qwen3.8-27B-Uncensored"
@@ -43,8 +44,7 @@ def test_complete_matrix_is_generated_not_hand_maintained() -> None:
     catalog = ModelCatalog.load(CATALOG_PATH)
     matrix = json.loads(MATRIX_PATH.read_text())
     validate_configuration_matrix(matrix, catalog)
-    expected = len(catalog.main_models) * len(catalog.auxiliary_options) * len(CONTEXTS)
-    assert expected == 552
+    expected = 546
     assert len(matrix["rows"]) == expected
     assert len({item["id"] for item in matrix["rows"]}) == expected
     assert {item["context"] for item in matrix["rows"]} == set(CONTEXTS)


### PR DESCRIPTION
## Summary
- model catalog entries may declare supported contexts
- constrain Maple Preview to its native 64K and 128K contexts
- regenerate the canonical matrix without invalid Maple 262K/1M rows
- add regression coverage for matrix generation and campaign planning

## Verification
- `23 passed, 1 skipped` focused Windows suite
- catalog campaign dry-run succeeds
- campaign status reports 546 valid rows with no recipe-resolution crash
- Maple 64K and 128K physical campaigns previously completed successfully on AMD RX 6600/Vulkan