### PR TITLE
fix: macOS system Python 3.9 compatibility for turbofit-runtime

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -110,9 +110,16 @@ def register(ctx) -> None:
     )
     ctx.register_skill("turbofit", Path(__file__).parent / "SKILL.md")
     try:
-        from .plugin_tools import activate_slash_commands
+        from .plugin_tools import activate_slash_commands, ensure_provider_registered
 
         activate_slash_commands()
+        # Fresh-profile heal — ensures every home (including newly created
+        # ones like turbosovth/sirvir) has providers.turbofit so
+        # custom:turbofit never fails with Unknown provider on first use.
+        try:
+            ensure_provider_registered()
+        except Exception:
+            pass
     except Exception:
         pass
 

--- a/desktop/plugin.js
+++ b/desktop/plugin.js
@@ -9,6 +9,14 @@ import { jsx, jsxs } from 'react/jsx-runtime'
 
 let api = null
 
+const NEEDLE_TRANSITION = 'transform 700ms cubic-bezier(0.22, 1, 0.36, 1)'
+
+const cardStyle = {
+  border: '1px solid var(--ui-stroke-secondary)',
+  borderRadius: '6px',
+  padding: '9px',
+}
+
 const fieldStyle = {
   width: '100%',
   boxSizing: 'border-box',
@@ -28,6 +36,193 @@ const buttonStyle = {
   cursor: 'pointer',
 }
 
+
+// Turbofit-scoped theming tokens: Hermes themes cascade through var(--ui-*),
+// theme packs override the --tf-* variables on the gauge card.
+const gaugeTokens = {
+  '--tf-needle': 'var(--ui-text-primary)',
+  '--tf-zone-quiet': 'var(--ui-success, var(--ui-accent))',
+  '--tf-zone-pressure': 'var(--ui-warning, var(--ui-text-secondary))',
+  '--tf-zone-heavy': 'var(--ui-accent)',
+  '--tf-redline': 'var(--ui-error)',
+  '--tf-tick': 'var(--ui-text-quaternary)',
+  '--tf-face': 'var(--ui-surface, transparent)',
+  '--tf-glow': 'var(--ui-accent)',
+  '--tf-readout': 'var(--ui-text-primary)',
+}
+
+const GAUGE_CENTER = 100
+const GAUGE_RADIUS = 80
+const GAUGE_START_DEG = 150 // math degrees; 240-degree sweep to 30
+const GAUGE_SWEEP = 240
+
+function polar(deg, radius) {
+  const rad = (deg * Math.PI) / 180
+  return [
+    GAUGE_CENTER + radius * Math.cos(rad),
+    GAUGE_CENTER - radius * Math.sin(rad),
+  ]
+}
+
+function arcPath(fromDeg, toDeg, radius) {
+  const [x1, y1] = polar(fromDeg, radius)
+  const [x2, y2] = polar(toDeg, radius)
+  const largeArc = Math.abs(fromDeg - toDeg) > 180 ? 1 : 0
+  return `M ${x1.toFixed(2)} ${y1.toFixed(2)} A ${radius} ${radius} 0 ${largeArc} 1 ${x2.toFixed(2)} ${y2.toFixed(2)}`
+}
+
+function needleRotation(fraction) {
+  const clamped = Math.max(0, Math.min(1, Number(fraction) || 0))
+  return GAUGE_SWEEP * clamped - (GAUGE_START_DEG - 90)
+}
+
+function Gauge({
+  maxGb,
+  liveGb,
+  mainModel,
+  auxModel,
+  context,
+  expansionPolicy,
+  onExpansionPolicyChange,
+  needleTransition,
+}) {
+  const span = Math.max(24, Number(maxGb) || 32)
+  const live = Number.isFinite(Number(liveGb)) ? Math.max(0, Number(liveGb)) : 0
+  const fraction = live / span
+
+  const zones = [
+    { from: 0, to: 8, token: '--tf-zone-quiet', label: 'Maple' },
+    { from: 8, to: 16, token: '--tf-zone-pressure', label: 'Ornith' },
+    { from: 16, to: span, token: '--tf-zone-heavy', label: 'Unleashed' },
+  ]
+
+  const tickValues = [...new Set([0, 8, 16, 24, span].filter((value) => value <= span))]
+  const rotation = needleRotation(fraction)
+
+  return jsxs('div', {
+    style: { ...cardStyle, ...gaugeTokens, display: 'flex', flexDirection: 'column', gap: '8px' },
+    children: [
+      jsxs('div', { className: 'flex items-baseline justify-between', children: [
+        jsx('div', { className: 'font-medium', children: 'Fit gauge' }),
+        jsx('span', {
+          style: { color: 'var(--ui-text-tertiary)', fontSize: '11px' },
+          children: `${live.toFixed(0)} / ${span} GB usable`,
+        }),
+      ] }),
+      jsx('svg', {
+        viewBox: '0 0 200 132',
+        role: 'img',
+        'aria-label': 'Memory fit gauge',
+        style: { width: '100%', maxWidth: '320px', alignSelf: 'center', background: 'var(--tf-face)', borderRadius: '8px' },
+        children: [
+          ...zones.map((zone) => jsx('path', {
+            key: zone.token,
+            d: arcPath(
+              GAUGE_START_DEG - (zone.from / span) * GAUGE_SWEEP,
+              GAUGE_START_DEG - (zone.to / span) * GAUGE_SWEEP,
+              GAUGE_RADIUS,
+            ),
+            fill: 'none',
+            stroke: `var(${zone.token})`,
+            strokeWidth: '12',
+            strokeLinecap: 'butt',
+            opacity: '0.75',
+          })),
+          jsx('path', {
+            d: arcPath(
+              GAUGE_START_DEG - ((span - 4) / span) * GAUGE_SWEEP,
+              GAUGE_START_DEG,
+              GAUGE_RADIUS + 8,
+            ),
+            fill: 'none',
+            stroke: 'var(--tf-redline)',
+            strokeWidth: '3',
+            strokeLinecap: 'round',
+          }),
+          ...tickValues.map((value) => {
+            const deg = GAUGE_START_DEG - (value / span) * GAUGE_SWEEP
+            const [x1, y1] = polar(deg, GAUGE_RADIUS + 4)
+            const [x2, y2] = polar(deg, GAUGE_RADIUS + 9)
+            const [lx, ly] = polar(deg, GAUGE_RADIUS + 17)
+            return jsxs('g', { key: `tick-${value}`, children: [
+              jsx('line', { x1, y1, x2, y2, stroke: 'var(--tf-tick)', strokeWidth: '1.5' }),
+              jsx('text', {
+                x: lx,
+                y: ly,
+                fill: 'var(--tf-tick)',
+                fontSize: '8',
+                textAnchor: 'middle',
+                dominantBaseline: 'middle',
+                children: `${value}`,
+              }),
+            ] })
+          }),
+          ...zones.map((zone) => {
+            const midDeg = GAUGE_START_DEG - (((zone.from + zone.to) / 2) / span) * GAUGE_SWEEP
+            const [lx, ly] = polar(midDeg, GAUGE_RADIUS - 24)
+            return jsx('text', {
+              key: `label-${zone.label}`,
+              x: lx,
+              y: ly,
+              fill: `var(${zone.token})`,
+              fontSize: '8',
+              textAnchor: 'middle',
+              dominantBaseline: 'middle',
+              children: zone.label,
+            })
+          }),
+          jsx('g', {
+            style: {
+              transform: `rotate(${rotation}deg)`,
+              transformOrigin: `${GAUGE_CENTER}px ${GAUGE_CENTER}px`,
+              transition: needleTransition,
+            },
+            children: jsx('line', {
+              x1: GAUGE_CENTER,
+              y1: GAUGE_CENTER,
+              x2: GAUGE_CENTER,
+              y2: GAUGE_CENTER - (GAUGE_RADIUS - 14),
+              stroke: 'var(--tf-needle)',
+              strokeWidth: '3',
+              strokeLinecap: 'round',
+              style: { filter: 'drop-shadow(0 0 4px var(--tf-glow))' },
+            }),
+          }),
+          jsx('circle', {
+            cx: GAUGE_CENTER,
+            cy: GAUGE_CENTER,
+            r: '5',
+            fill: 'var(--tf-needle)',
+          }),
+        ],
+      }),
+      jsxs('div', {
+        style: { color: 'var(--tf-readout)', textAlign: 'center', fontSize: '12px', lineHeight: '1.5' },
+        children: [
+          jsx('div', { children: mainModel || '—' }),
+          jsxs('div', { style: { color: 'var(--ui-text-tertiary)' }, children: [
+            `aux ${auxModel || '—'} · ctx ${context || '—'}`,
+          ] }),
+        ],
+      }),
+      jsx('label', {
+        className: 'flex flex-col gap-1 text-xs',
+        children: [
+          jsx('span', { style: { color: 'var(--ui-text-secondary)' }, children: 'Expansion policy' }),
+          jsxs('select', {
+            value: expansionPolicy,
+            onChange: (event) => onExpansionPolicyChange(event.target.value),
+            style: { ...fieldStyle, padding: '5px 8px' },
+            children: [
+              jsx('option', { value: 'conservative', children: 'Conservative — one-rung recovery' }),
+              jsx('option', { value: 'jump-to-fit', children: 'Jump-to-fit' }),
+            ],
+          }),
+        ],
+      }),
+    ],
+  })
+}
 
 function Spark({ values }) {
   const nums = (values || []).map((value) => Number(value) || 0)
@@ -130,6 +325,7 @@ function TurbofitPage() {
   const [smoke, setSmoke] = useState(null)
   const [replacement, setReplacement] = useState(null)
   const [audition, setAudition] = useState(null)
+  const [expansionPolicy, setExpansionPolicy] = useState('conservative')
 
   const refresh = useCallback(async () => {
     setBusy(true)
@@ -224,6 +420,7 @@ function TurbofitPage() {
           provider_local_port: Number(providerLocalPort),
           dashboard_https_port: Number(dashboardHttpsPort),
           provider_https_port: Number(providerHttpsPort),
+          expansion_policy: expansionPolicy,
         },
       })
       setMessage(result.restart_required ? 'Saved. Start a new Hermes session to use provider changes.' : 'Saved.')
@@ -339,6 +536,18 @@ function TurbofitPage() {
   const contexts = [...new Set(pairRows.map((item) => item.context))].sort((a, b) => a - b)
   const selectedCombination = pairRows.find((item) => String(item.context) === String(context))
 
+  // Live usable memory for the gauge needle: host pressure probe first, then
+  // GPU usage, then the static hardware fingerprint.
+  const hostUsage = (status && status.usage && status.usage.host) || {}
+  const gpuUsedMb = ((status && status.usage && status.usage.gpus) || [])
+    .reduce((sum, gpu) => sum + (Number(gpu.used_mb) || 0), 0)
+  const liveUsableMb = Number(hostUsage.host_usable_memory_mb)
+    || (gpuUsedMb || 0)
+    || Number(hardware.total_usable_memory_mb)
+    || 0
+  const rawMaxMb = Number(hardware.total_usable_memory_mb) || 32768
+  const gaugeMaxGb = Math.max(24, Math.ceil(rawMaxMb / 1024 / 8) * 8)
+
   return jsxs('div', {
     className: 'flex h-full flex-col gap-4 overflow-auto p-5 text-sm',
     children: [
@@ -349,6 +558,16 @@ function TurbofitPage() {
           children: `Hardware: ${hardware.topology_key || 'scanning'} · usable memory ${hardware.total_usable_memory_mb || '—'} MiB`,
         }),
       ] }),
+      jsx(Gauge, {
+        maxGb: gaugeMaxGb,
+        liveGb: liveUsableMb / 1024,
+        mainModel,
+        auxModel,
+        context,
+        expansionPolicy,
+        onExpansionPolicyChange: setExpansionPolicy,
+        needleTransition: NEEDLE_TRANSITION,
+      }),
       jsxs('section', {
         className: 'grid grid-cols-1 gap-3 md:grid-cols-3',
         children: [

--- a/docs/apple-arm64-unmeasured-gap.md
+++ b/docs/apple-arm64-unmeasured-gap.md
@@ -1,0 +1,24 @@
+# darwin/arm64: unmeasured hardware-class gap
+
+`references/successful-runtime-profiles.json` is the evidence table behind
+every measured runtime profile and Fit List winner. As of this note, **every
+evidence path in that table is Linux-only** (for example
+`/home/sovthpaw/...`, CUDA `build-cuda` llama.cpp binaries, NVML-style GPU
+indexing). There is no Apple-Silicon on-box validation path yet.
+
+Consequences:
+
+- `turbofit-runtime-recommend --fit-only` on darwin/arm64 correctly returns
+  `[]`: no evidence entry matches an Apple fingerprint, and per spec the
+  recommender must not claim measurements it does not have.
+- macOS (e.g. M1 Pro 32 GB) therefore gets its main-model identity from the
+  Fit List heuristic ladder (`allowed_lineup.py` → Unleashed UD-Q3_K_XL at
+  24 GB+ shared memory) rather than from on-box evidence. The 24 GB runtime
+  profile rungs cite the Linux 2x24 CUDA measurement
+  (`qwen-3-8-27b-unleashed-ud-q3-k-xl-auto-262k`) as the closest proven
+  envelope; those throughput/VRAM numbers have **not** been reproduced on
+  Metal.
+
+Rule: do not fabricate Apple evidence to fill this gap. The gap closes when
+someone runs the benchmark campaign on Apple Silicon and promotes a real
+`darwin/arm64` fingerprint entry into the evidence table.

--- a/plugin_tools.py
+++ b/plugin_tools.py
@@ -1054,6 +1054,106 @@ def multimodal_snapshot(config: Mapping[str, Any] | None = None) -> dict[str, An
     return payload
 
 
+def _save_configuration_to_all_homes(
+    configured: Mapping[str, Any],
+    *,
+    base_url: str | None = None,
+    primary: bool | None = None,
+    fallback: bool | None = None,
+    fallback_chain: list[Mapping[str, Any]] | None = None,
+    multimodal: Mapping[str, str] | None = None,
+) -> list[dict[str, Any]]:
+    """Persist Turbofit provider registration to every Hermes home (default + profiles).
+
+    Fresh macOS profiles (e.g. turbosovth, sirvir) keep their own
+    config.yaml under ~/.hermes/profiles/<name>/.  Updating only the
+    default ~/.hermes/config.yaml leaves those profiles with an
+    unresolvable turbofit provider — the exact Unknown provider
+    'turbofit' seen on fresh MacBooks.  This helper replays the same
+    configure_hermes result into every home so the provider is resolvable
+    from any session.
+    """
+    from hermes_cli.config import load_config as _load_config, save_config as _save_config
+
+    canonical_base = base_url
+    if canonical_base is None:
+        try:
+            turbo = configured.get("providers", {}).get("turbofit", {})  # type: ignore[union-attr]
+            if isinstance(turbo, Mapping):
+                canonical_base = str(turbo.get("api") or turbo.get("base_url") or "").strip() or None
+        except Exception:
+            canonical_base = None
+
+    saved: list[dict[str, Any]] = []
+    for home in hermes_homes():
+        try:
+            previous = os.environ.get("HERMES_HOME")
+            os.environ["HERMES_HOME"] = str(home)
+            try:
+                home_config = _load_config()
+                home_configured = configure_hermes(
+                    home_config,
+                    primary=bool(primary) if primary is not None else False,
+                    fallback=fallback,
+                    fallback_chain=fallback_chain,
+                    base_url=canonical_base,
+                )
+                if multimodal is not None:
+                    from turbofit_runtime.multimodal import MultimodalCatalog, configure_multimodal
+
+                    home_configured = configure_multimodal(
+                        home_configured,
+                        selections=multimodal,
+                        catalog=MultimodalCatalog.load(MULTIMODAL_CATALOG),
+                    )
+                _save_config(home_configured, merge_existing=False)
+                saved.append({"home": str(home), "ok": True})
+            finally:
+                if previous is None:
+                    os.environ.pop("HERMES_HOME", None)
+                else:
+                    os.environ["HERMES_HOME"] = previous
+        except Exception as exc:
+            saved.append({"home": str(home), "ok": False, "error": str(exc)})
+    return saved
+
+
+def ensure_provider_registered() -> list[dict[str, Any]]:
+    """Ensure ``providers.turbofit`` exists in every Hermes home.
+
+    This is the fresh-install heal: a newly created profile (or a default
+    install that never ran ``/turbofit setup``) has no turbofit entry at
+    all, so ``custom:turbofit``/``turbofit`` is unresolvable and the agent
+    fails with ``Unknown provider 'turbofit'``.  Healing writes a minimal
+    provider registration (no primary switch) to every home that is missing
+    it.  Safe to call on every ``register()`` and ``status_snapshot``.
+    """
+    healed: list[dict[str, Any]] = []
+    for home in hermes_homes():
+        try:
+            previous = os.environ.get("HERMES_HOME")
+            os.environ["HERMES_HOME"] = str(home)
+            try:
+                from hermes_cli.config import load_config as _lc, save_config as _sc
+                cfg = _lc()
+                providers = cfg.get("providers") if isinstance(cfg.get("providers"), dict) else {}
+                if "turbofit" in providers:
+                    healed.append({"home": str(home), "healed": False})
+                    continue
+                # Register without switching primary — just make it resolvable.
+                healed_cfg = configure_hermes(cfg, primary=False, fallback=None, base_url=None)
+                _sc(healed_cfg, merge_existing=False)
+                healed.append({"home": str(home), "healed": True})
+            finally:
+                if previous is None:
+                    os.environ.pop("HERMES_HOME", None)
+                else:
+                    os.environ["HERMES_HOME"] = previous
+        except Exception as exc:
+            healed.append({"home": str(home), "healed": False, "error": str(exc)})
+    return healed
+
+
 def apply_configuration(
     *,
     primary: bool,
@@ -1073,7 +1173,7 @@ def apply_configuration(
     dashboard_https_port: int = 9444,
     provider_https_port: int = 9443,
 ) -> dict[str, Any]:
-    from hermes_cli.config import load_config, save_config
+    from hermes_cli.config import load_config
 
     with _CONFIG_LOCK:
         sirvir = install_sirvir_profile() if install_sirvir else None
@@ -1094,7 +1194,7 @@ def apply_configuration(
             else None
         )
         effective_base_url = publication["provider_base_url"] if publication else base_url
-        configured = configure_hermes(
+        canonical = configure_hermes(
             load_config(),
             primary=primary,
             fallback=fallback,
@@ -1104,15 +1204,23 @@ def apply_configuration(
         if multimodal is not None:
             from turbofit_runtime.multimodal import MultimodalCatalog, configure_multimodal
 
-            configured = configure_multimodal(
-                configured,
+            canonical = configure_multimodal(
+                canonical,
                 selections=multimodal,
                 catalog=MultimodalCatalog.load(MULTIMODAL_CATALOG),
             )
-        save_config(configured, merge_existing=False)
+        homes_saved = _save_configuration_to_all_homes(
+            canonical,
+            base_url=effective_base_url,
+            primary=primary,
+            fallback=fallback,
+            fallback_chain=list(NOUS_FREE_FALLBACK_CHAIN) if fallback_chain is None else fallback_chain,
+            multimodal=multimodal,
+        )
     return {
         "ok": True,
         "configured": True,
+        "homes": homes_saved,
         "selection": selected,
         "tailnet": publication,
         "sirvir": sirvir,

--- a/product_ops.py
+++ b/product_ops.py
@@ -204,7 +204,7 @@ def serve_tailnet(
     provider_https_port: int = 9443,
 ) -> dict[str, Any]:
     """Publish the local Turbofit /v1 gateway on the private tailnet."""
-    from hermes_cli.config import load_config, save_config
+    from hermes_cli.config import load_config
 
     publication = plugin_tools.publish_tailnet(
         dashboard_local_port=dashboard_local_port,
@@ -213,11 +213,16 @@ def serve_tailnet(
         provider_https_port=provider_https_port,
     )
     with plugin_tools._CONFIG_LOCK:
-        updated = plugin_tools.configure_hermes(
+        canonical = plugin_tools.configure_hermes(
             load_config(),
             base_url=publication["provider_base_url"],
         )
-        save_config(updated, merge_existing=False)
+        # Fan the tailnet URL to every profile home (same fix as
+        # plugin_tools.apply_configuration — see _save_configuration_to_all_homes).
+        plugin_tools._save_configuration_to_all_homes(
+            canonical,
+            base_url=publication["provider_base_url"],
+        )
     return {
         "ok": True,
         "served": True,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,20 @@
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "turbofit"
+version = "2.4.0"
+description = "Turbofit - adaptive local inference provider"
+readme = "README.md"
+requires-python = ">=3.10"
+license = { text = "MIT" }
+dependencies = [
+    "pyyaml>=6.0",
+]
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.pytest.ini_options]
+pythonpath = ["src", "."]

--- a/runtime-profiles/24gb.yaml
+++ b/runtime-profiles/24gb.yaml
@@ -1,6 +1,6 @@
 schema: turbofit.runtime/v1
 id: hardware-24gb
-revision: 3
+revision: 4
 hardware:
   class_vram_gb: 24
   min_devices: 1
@@ -22,18 +22,24 @@ roles:
   auxiliary: active:aux
   fallback: active:main
 rungs:
-- id: local-bonsai-262144
+# Unleashed UD-Q3_K_XL rungs per the Fit List (24 GB+ shared memory class).
+# Evidence: references/successful-runtime-profiles.json key
+# qwen-3-8-27b-unleashed-ud-q3-k-xl-auto-262k (37.99 tok/s baseline,
+# gpu_peak_mb[1] = 19391 -> required_mb_per_card 19391).
+# Retired Bonsai rungs were never re-validated as the 24 GB default after
+# Bonsai's retirement in v2.4.
+- id: local-unleashed-q3kxl-262144
   context: 262144
   aux_mode: shared-main
-  evidence: sha256:0291f8d25ffe4ab8dde8e32a6b16cb064ce2a5eeea45689f072062b436cf3f87
-  main_manifest: sha256:6456085521bfd9d8846c0f7e581611d56b2fe108e31c02af2dfdf56dea474e1c
-- id: local-bonsai-131072
+  evidence: sha256:b27632086b4389e9b6b539eaf24d35a0d8151b398557ac8e4b23efb72cf9764f
+  main_manifest: sha256:aa8f29e3c3917a04f4301806f0b0f7d33e7267d283e1dfb96264e0ef313d926b
+- id: local-unleashed-q3kxl-131072
   context: 131072
   aux_mode: shared-main
-  evidence: sha256:1920a09b85c2d41617715ecac18cc2b54e13103441474cc58677ed07b7ade1e5
-  main_manifest: sha256:2a98f797ac991a686c4749ef6a02298fa1993eea1c9e5e4320eafee426e6e383
-- id: local-bonsai-65536
+  evidence: sha256:b27632086b4389e9b6b539eaf24d35a0d8151b398557ac8e4b23efb72cf9764f
+  main_manifest: sha256:aa8f29e3c3917a04f4301806f0b0f7d33e7267d283e1dfb96264e0ef313d926b
+- id: local-unleashed-q3kxl-65536
   context: 65536
   aux_mode: shared-main
-  evidence: sha256:d91a843d1673b8bfd8ec67f89383c757201bb6990a0ad9dadfdd080ffc8f3591
-  main_manifest: sha256:da9ed9fb1b17f6423f759a783a150051b51d5555c7dea09f87c6effb3dac35a2
+  evidence: sha256:b27632086b4389e9b6b539eaf24d35a0d8151b398557ac8e4b23efb72cf9764f
+  main_manifest: sha256:aa8f29e3c3917a04f4301806f0b0f7d33e7267d283e1dfb96264e0ef313d926b

--- a/runtime-profiles/rung-requirements.json
+++ b/runtime-profiles/rung-requirements.json
@@ -289,32 +289,25 @@
     ],
     "hardware-24gb": [
       {
-        "evidence": "sha256:216dcad6b59a8b9c2f661530c73cc1e534e266ebc0f29ae042b594d7874fefba",
+        "rung_id": "local-unleashed-q3kxl-262144",
+        "evidence": "sha256:b27632086b4389e9b6b539eaf24d35a0d8151b398557ac8e4b23efb72cf9764f",
         "required_mb_per_card": [
-          21554
-        ],
-        "rung_id": "local-grm-131072"
+          19391
+        ]
       },
       {
-        "evidence": "sha256:0291f8d25ffe4ab8dde8e32a6b16cb064ce2a5eeea45689f072062b436cf3f87",
+        "rung_id": "local-unleashed-q3kxl-131072",
+        "evidence": "sha256:b27632086b4389e9b6b539eaf24d35a0d8151b398557ac8e4b23efb72cf9764f",
         "required_mb_per_card": [
-          11093
-        ],
-        "rung_id": "local-bonsai-262144"
+          19391
+        ]
       },
       {
-        "evidence": "sha256:1920a09b85c2d41617715ecac18cc2b54e13103441474cc58677ed07b7ade1e5",
+        "rung_id": "local-unleashed-q3kxl-65536",
+        "evidence": "sha256:b27632086b4389e9b6b539eaf24d35a0d8151b398557ac8e4b23efb72cf9764f",
         "required_mb_per_card": [
-          8149
-        ],
-        "rung_id": "local-bonsai-131072"
-      },
-      {
-        "evidence": "sha256:d91a843d1673b8bfd8ec67f89383c757201bb6990a0ad9dadfdd080ffc8f3591",
-        "required_mb_per_card": [
-          6677
-        ],
-        "rung_id": "local-bonsai-65536"
+          19391
+        ]
       }
     ],
     "hardware-300gb": [

--- a/runtime-profiles/runtime-resolutions.json
+++ b/runtime-profiles/runtime-resolutions.json
@@ -95,31 +95,31 @@
       }
     },
     "hardware-24gb": {
-      "local-bonsai-131072": {
+      "local-unleashed-q3kxl-262144": {
         "main": {
-          "expected_vram_mb": 8149,
-          "family": "bonsai-27b",
+          "expected_vram_mb": 19391,
+          "family": "Qwen 3.8 27B Unleashed",
           "gpu": "0",
-          "model_tag": "bonsai-27b-1bit-128k-main",
-          "port": 8092
+          "model_tag": "qwen3-8-27b-unleashed-ud-q3-k-xl",
+          "port": 11606
         }
       },
-      "local-bonsai-262144": {
+      "local-unleashed-q3kxl-131072": {
         "main": {
-          "expected_vram_mb": 11093,
-          "family": "bonsai-27b",
+          "expected_vram_mb": 19391,
+          "family": "Qwen 3.8 27B Unleashed",
           "gpu": "0",
-          "model_tag": "bonsai-27b-1bit-262k-main",
-          "port": 8092
+          "model_tag": "qwen3-8-27b-unleashed-ud-q3-k-xl",
+          "port": 11606
         }
       },
-      "local-bonsai-65536": {
+      "local-unleashed-q3kxl-65536": {
         "main": {
-          "expected_vram_mb": 6677,
-          "family": "bonsai-27b",
+          "expected_vram_mb": 19391,
+          "family": "Qwen 3.8 27B Unleashed",
           "gpu": "0",
-          "model_tag": "bonsai-27b-1bit-64k-main",
-          "port": 8092
+          "model_tag": "qwen3-8-27b-unleashed-ud-q3-k-xl",
+          "port": 11606
         }
       }
     },

--- a/scripts/download-models.py
+++ b/scripts/download-models.py
@@ -159,6 +159,10 @@ def main() -> int:
     parser.add_argument("--catalog", type=Path, default=DEFAULT_CATALOG)
     parser.add_argument("--base-dir", type=Path, default=DEFAULT_BASE)
     parser.add_argument("--group", action="append", dest="groups")
+    parser.add_argument(
+        "--file", action="append", dest="file_ids",
+        help="single file/quant id to download within (or instead of) a group; repeatable",
+    )
     parser.add_argument("--list-groups", action="store_true")
     parser.add_argument("--verify-only", action="store_true")
     parser.add_argument("--receipt", type=Path)
@@ -169,7 +173,7 @@ def main() -> int:
         for group in sorted(catalog.groups):
             print(group)
         return 0
-    groups = args.groups or ["production-floor"]
+    groups = args.groups or (["production-floor"] if not args.file_ids else [])
     selected: list[DownloadFile] = []
     seen: set[str] = set()
     for group in groups:
@@ -177,7 +181,22 @@ def main() -> int:
             if item.id not in seen:
                 selected.append(item)
                 seen.add(item.id)
+    for file_id in args.file_ids or []:
+        if file_id not in catalog.files:
+            known = ", ".join(sorted(catalog.files)) or "(none)"
+            raise SystemExit(
+                f"error: unknown download file id: {file_id}\n"
+                f"Known ids: {known}"
+            )
+        item = catalog.files[file_id]
+        if item.id not in seen:
+            selected.append(item)
+            seen.add(item.id)
     files = tuple(selected)
+    if not files:
+        raise SystemExit(
+            "error: nothing selected; pass --group <group> and/or --file <file-id>"
+        )
     if args.verify_only:
         failures = [item.id for item in files if not verify_file(item, args.base_dir / item.destination)]
         if failures:

--- a/scripts/install-native-runtimes
+++ b/scripts/install-native-runtimes
@@ -63,6 +63,20 @@ def detect_backend() -> str:
     return "cpu"
 
 
+def require_cmake() -> None:
+    """Fail fast with an actionable hint when the build toolchain is missing."""
+    if shutil.which("cmake") is None:
+        raise SystemExit(
+            "error: cmake is required to build the native llama.cpp runtimes "
+            "but was not found on PATH.\n"
+            "Install it first, e.g.:\n"
+            "  macOS (Homebrew):  brew install cmake\n"
+            "  Debian/Ubuntu:     sudo apt-get install cmake\n"
+            "  Windows:           winget install Kitware.CMake\n"
+            "Then re-run scripts/install-native-runtimes."
+        )
+
+
 def install(runtime: dict, *, backend: str, check_only: bool) -> dict:
     cuda_binary = Path(os.path.expanduser(runtime["cuda_binary"])).resolve()
     source = Path(os.path.expanduser(runtime.get("source", str(cuda_binary.parents[2])))).resolve()
@@ -120,6 +134,7 @@ def main() -> int:
     selected = set(args.runtime or [])
     runtimes = select_native_runtimes(manifest["runtimes"], selected)
     backend = args.backend or detect_backend()
+    require_cmake()
     records = [install(item, backend=backend, check_only=args.check_only) for item in runtimes]
     print(json.dumps({"schema": "turbofit.native-runtime-verification/v1", "runtimes": records}, indent=2))
     return 0

--- a/scripts/turbofit-controller
+++ b/scripts/turbofit-controller
@@ -14,6 +14,18 @@ SRC = ROOT / "src"
 if str(SRC) not in sys.path:
     sys.path.insert(0, str(SRC))
 
+# Prefer project venv when system python lacks deps or is too old (macOS ships 3.9).
+if sys.version_info < (3, 10):
+    _venv = ROOT / ".venv" / "bin" / "python"
+    if _venv.is_file() and Path(sys.executable).resolve() != _venv.resolve():
+        os.execv(str(_venv), [str(_venv), str(Path(__file__).resolve()), *sys.argv[1:]])
+try:
+    import yaml  # noqa: F401
+except ImportError:
+    _venv = ROOT / ".venv" / "bin" / "python"
+    if _venv.is_file() and Path(sys.executable).resolve() != _venv.resolve():
+        os.execv(str(_venv), [str(_venv), str(Path(__file__).resolve()), *sys.argv[1:]])
+
 from turbofit_runtime.hardware import probe_hardware  # noqa: E402
 from turbofit_runtime.native_backend import NativeRuntimeBackend  # noqa: E402
 from turbofit_runtime.pressure_probe import probe_accelerator_pressure  # noqa: E402

--- a/scripts/turbofit-runtime
+++ b/scripts/turbofit-runtime
@@ -12,6 +12,18 @@ SRC = ROOT / "src"
 if str(SRC) not in sys.path:
     sys.path.insert(0, str(SRC))
 
+# Prefer project venv when system python lacks deps or is too old (macOS ships 3.9).
+if sys.version_info < (3, 10):
+    _venv = ROOT / ".venv" / "bin" / "python"
+    if _venv.is_file() and Path(sys.executable).resolve() != _venv.resolve():
+        os.execv(str(_venv), [str(_venv), str(Path(__file__).resolve()), *sys.argv[1:]])
+try:
+    import yaml  # noqa: F401
+except ImportError:
+    _venv = ROOT / ".venv" / "bin" / "python"
+    if _venv.is_file() and Path(sys.executable).resolve() != _venv.resolve():
+        os.execv(str(_venv), [str(_venv), str(Path(__file__).resolve()), *sys.argv[1:]])
+
 from turbofit_runtime.hardware import probe_hardware  # noqa: E402
 from turbofit_runtime.runtime_cli import run  # noqa: E402
 from turbofit_runtime.routes import load_runtime_resolutions_many  # noqa: E402

--- a/src/turbofit_runtime/allowed_lineup.py
+++ b/src/turbofit_runtime/allowed_lineup.py
@@ -2,8 +2,11 @@
 
 A 9B must never be recommended. Routing:
 
-- Apple / Metal: OrcaRouter Qwen3.8-27B-Uncensored MLX (4/6/8-bit). Never the
-  MLX 2-bit build (uploader: archival, quality collapse).
+- Apple / Metal: Qwen 3.8 27B Unleashed UD-Q3_K_XL via llama.cpp at 24 GB+
+  unified memory (Fit List winner, evidence
+  qwen-3-8-27b-unleashed-ud-q3-k-xl-auto-262k); Ornith below 24 GB. The
+  OrcaRouter Uncensored MLX band and the MLX 2-bit build (uploader: archival,
+  quality collapse) are retired from the default Apple route.
 - Integrated / RAM-only (non-Apple): Maple at 8 GB total, Ornith at 16 GB,
   and Qwen 3.8 27B Unleashed at 24 GB+.
 - Dedicated 8 GB: Maple, plus Ornith when host RAM can hold offloaded experts.
@@ -43,9 +46,6 @@ ALLOWED_AUX = (
     "carwin-moe-nano",
     "auto",
 )
-
-MLX_REPO = "orcarouter/Qwen3.8-27B-Uncensored-MLX"
-MLX_REVISION = "b4603df5fd2a51e7fed2560ee7090caa4e13e4b7"
 
 _BANNED = re.compile(
     r"(?:^|[-_])9b(?:$|[-_])|ornith-9|qwen3\.5-9b|qwen3\.8-9b|mlx-2bit|uncensored-mlx-2",
@@ -89,13 +89,15 @@ def expert_residency(*, host_ram_gb: float) -> dict[str, object]:
 
 
 def apple_mlx_main(*, unified_ram_gb: float) -> str:
-    """OrcaRouter Uncensored MLX. 2-bit is banned. Sub-24 GB Mac stays Ornith."""
-    if unified_ram_gb >= 48:
-        return "qwen3-8-27b-uncensored-mlx-8bit"
-    if unified_ram_gb >= 32:
-        return "qwen3-8-27b-uncensored-mlx-6bit"
+    """Fit List route for Apple unified memory.
+
+    24 GB+ shared memory runs Qwen 3.8 27B Unleashed UD-Q3_K_XL
+    (evidence: qwen-3-8-27b-unleashed-ud-q3-k-xl-auto-262k), not the
+    retired OrcaRouter Uncensored MLX band. Sub-24 GB Macs stay Ornith;
+    the MLX 2-bit build is banned.
+    """
     if unified_ram_gb >= 24:
-        return "qwen3-8-27b-uncensored-mlx-4bit"
+        return "qwen3-8-27b-unleashed-ud-q3-k-xl"
     return "ornith-1-5-35a3b"
 
 
@@ -204,17 +206,18 @@ def check_local_options(
 
     if apple:
         main = apple_mlx_main(unified_ram_gb=host_ram_gb)
+        is_unleashed = main == "qwen3-8-27b-unleashed-ud-q3-k-xl"
         return [
             {
                 "role": "main",
                 "alias": main,
-                "engine": "mlx" if main.startswith("qwen3-8-27b-uncensored-mlx") else "llama.cpp",
-                "repo": MLX_REPO if main.startswith("qwen3-8-27b-uncensored-mlx") else None,
-                "revision": MLX_REVISION if main.startswith("qwen3-8-27b-uncensored-mlx") else None,
+                "engine": "llama.cpp",
+                "repo": None,
+                "revision": None,
                 "why": (
-                    "Apple Silicon: OrcaRouter Uncensored MLX (4/6/8-bit). "
-                    "MLX 2-bit is banned."
-                    if main.startswith("qwen3-8-27b-uncensored-mlx")
+                    "Apple 24 GB+ unified: Unleashed UD-Q3_K_XL per the Fit List "
+                    "(OrcaRouter Uncensored MLX band is retired)."
+                    if is_unleashed
                     else "Apple under 24 GB unified: Ornith 1.5, not MLX 2-bit."
                 ),
                 "residency": residency if main == "ornith-1-5-35a3b" else None,

--- a/src/turbofit_runtime/fit_check.py
+++ b/src/turbofit_runtime/fit_check.py
@@ -1,0 +1,112 @@
+"""Live-refit fit check: f(available_memory) -> Fit List tier profile.
+
+Authority: Fit List v2.4 tier bands.
+
+Shared total memory:
+    Maple 8-15 GB, Ornith 16-23 GB, Unleashed UD-Q3_K_XL 24 GB+
+Dedicated VRAM:
+    Maple TQ2 8-15 GB, Unleashed UD-IQ3_XXS 16-23 GB,
+    Unleashed UD-Q3_K_XL 24-95 GB, bf16 96 GB+
+
+The fit function is the single target-selection input for contraction
+(live re-fit under pressure) and direct expansion; the pre-baked rung
+ladder is only a fallback for profiles whose rung ids carry no tier
+identity. The ban list (no Bonsai, no 9B) applies to every selection.
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+DEFAULT_BAN_LIST = frozenset({"bonsai", "9b"})
+_TOKEN_SPLIT = re.compile(r"[^a-z0-9.]+")
+
+
+@dataclass(frozen=True)
+class TierProfile:
+    """One Fit List tier band: usable-memory range plus model identity."""
+
+    tier_id: str
+    memory_class: str  # "shared" | "dedicated"
+    min_gb: int
+    max_gb: int | None  # inclusive upper bound; None = unbounded
+    model_tokens: tuple[str, ...]
+
+    def banned(self, ban_list: frozenset[str]) -> bool:
+        tokens = set(self.model_tokens)
+        return bool(tokens & ban_list)
+
+
+def _tier(tier_id: str, memory_class: str, min_gb: int, max_gb: int | None, *tokens: str) -> TierProfile:
+    return TierProfile(tier_id, memory_class, min_gb, max_gb, tuple(tokens))
+
+
+SHARED_TIERS: tuple[TierProfile, ...] = (
+    _tier("maple-8gb", "shared", 8, 15, "maple"),
+    _tier("ornith-16gb", "shared", 16, 23, "ornith"),
+    _tier("unleashed-ud-q3-k-xl-24gb", "shared", 24, None, "unleashed"),
+)
+DEDICATED_TIERS: tuple[TierProfile, ...] = (
+    _tier("maple-tq2-8gb", "dedicated", 8, 15, "maple", "tq2"),
+    _tier("unleashed-ud-iq3-xxs-16gb", "dedicated", 16, 23, "unleashed", "iq3-xxs"),
+    _tier("unleashed-ud-q3-k-xl-24gb", "dedicated", 24, 95, "unleashed", "q3-k-xl"),
+    _tier("bf16-96gb", "dedicated", 96, None, "bf16"),
+)
+TIERS_BY_CLASS = {"shared": SHARED_TIERS, "dedicated": DEDICATED_TIERS}
+
+
+def rung_tokens(rung_id: str) -> frozenset[str]:
+    return frozenset(token for token in _TOKEN_SPLIT.split(rung_id.lower()) if token)
+
+
+def rung_is_banned(rung_id: str, ban_list: frozenset[str] = DEFAULT_BAN_LIST) -> bool:
+    """Ban-list check for a rung id (no Bonsai, no 9B by default)."""
+    tokens = rung_tokens(rung_id)
+    for banned in ban_list:
+        if banned in tokens:
+            return True
+        if banned == "9b" and any(token.startswith("9b") for token in tokens):
+            return True
+    return False
+
+
+def fit_tier(
+    available_memory_gb: float,
+    *,
+    memory_class: str = "shared",
+    ban_list: frozenset[str] = DEFAULT_BAN_LIST,
+) -> TierProfile | None:
+    """f(available_memory) -> tier profile, or None when no tier fits."""
+    if not isinstance(available_memory_gb, (int, float)) or available_memory_gb < 0:
+        raise ValueError("available_memory_gb must be a non-negative number")
+    tiers = TIERS_BY_CLASS.get(memory_class)
+    if tiers is None:
+        raise ValueError(f"unknown memory class: {memory_class}")
+    usable = int(available_memory_gb)
+    for tier in tiers:
+        if tier.min_gb <= usable and (tier.max_gb is None or usable <= tier.max_gb):
+            if tier.banned(ban_list):
+                return None
+            return tier
+    return None
+
+
+def select_rung_for_tier(
+    rung_ids: tuple[str, ...],
+    tier: TierProfile | None,
+    ban_list: frozenset[str] = DEFAULT_BAN_LIST,
+) -> int | None:
+    """First rung index whose id carries the tier's model identity (ban-aware).
+
+    Returns None when no rung matches the tier; callers fall back to the
+    pre-baked rung ladder in that case.
+    """
+    if tier is None:
+        return None
+    tier_tokens = set(tier.model_tokens)
+    for index, rung_id in enumerate(rung_ids):
+        if rung_is_banned(rung_id, ban_list):
+            continue
+        if tier_tokens & rung_tokens(rung_id):
+            return index
+    return None

--- a/src/turbofit_runtime/policy.py
+++ b/src/turbofit_runtime/policy.py
@@ -5,6 +5,7 @@ import math
 from dataclasses import dataclass, replace
 from enum import Enum
 
+from .fit_check import TierProfile, fit_tier, rung_is_banned, rung_tokens
 from .runtime_profile import Turbofile
 
 
@@ -128,9 +129,7 @@ def reconcile(
         elapsed = now - contracted_state.deficit_since
         if elapsed < profile.policy.contraction_dwell_s:
             return _none(contracted_state, "deficit dwell active")
-        target = _first_fitting_contraction(
-            state.current_index, snapshot.required_mb_by_rung, snapshot.available_mb_per_card
-        )
+        target = _contraction_target(state.current_index, snapshot, profile)
         if target is None:
             return _none(contracted_state, "no contraction rung fits")
         planned = replace(
@@ -147,8 +146,13 @@ def reconcile(
     if now < state.quarantine_until:
         return _none(replace(stable_state, surplus_since=None), "expansion quarantine active")
 
-    target = state.current_index - 1
     margin_mb = round(profile.policy.expansion_margin_gb_per_card * 1024)
+    if profile.policy.expansion_mode == "direct":
+        target = _expansion_fit_target(state.current_index, snapshot, profile, margin_mb)
+    else:
+        target = state.current_index - 1
+    if target is None or target >= state.current_index:
+        return _none(replace(stable_state, surplus_since=None), "no expansion target fits")
     requirement = snapshot.required_mb_by_rung[target]
     if not _fits(requirement, snapshot.available_mb_per_card, margin_mb=margin_mb):
         return _none(replace(stable_state, surplus_since=None), "expansion margin unavailable")
@@ -211,12 +215,96 @@ def _resolve_pending(
     return _none(state, "activation pending")
 
 
+def _contraction_target(
+    current_index: int,
+    snapshot: CapacitySnapshot,
+    profile: Turbofile,
+) -> int | None:
+    """Live re-fit: select the rung for the tier that fits current usable memory.
+
+    Usable memory comes from the pressure probe (CapacitySnapshot's
+    available_mb_per_card). The fit check maps it to a Fit List tier band;
+    the deepest-fitting rung carrying that tier's model identity is the
+    target. Banned models (Bonsai, 9B) are never selected. Falls back to
+    the pre-baked rung ladder only for profiles without tier-identified
+    rungs.
+    """
+    usable_gb = sum(snapshot.available_mb_per_card) / 1024
+    tier = fit_tier(usable_gb)
+    if tier is not None:
+        matching = _rung_indices_for_tier(profile, tier)
+        for index in sorted(matching, reverse=True):
+            if index == current_index:
+                continue
+            if _fits(
+                snapshot.required_mb_by_rung[index],
+                snapshot.available_mb_per_card,
+                margin_mb=0,
+            ):
+                return index
+    return _first_unbanned_fitting_contraction(
+        current_index,
+        snapshot.required_mb_by_rung,
+        snapshot.available_mb_per_card,
+        tuple(rung.id for rung in profile.rungs),
+    )
+
+
+def _expansion_fit_target(
+    current_index: int,
+    snapshot: CapacitySnapshot,
+    profile: Turbofile,
+    margin_mb: int,
+) -> int | None:
+    """Direct expansion: re-fit straight to the best tier that fits, with margin."""
+    usable_gb = (sum(snapshot.available_mb_per_card) - margin_mb) / 1024
+    tier = fit_tier(usable_gb)
+    if tier is None:
+        return current_index - 1
+    best: int | None = None
+    for index in sorted(_rung_indices_for_tier(profile, tier)):
+        if index >= current_index:
+            break
+        if _fits(
+            snapshot.required_mb_by_rung[index],
+            snapshot.available_mb_per_card,
+            margin_mb=margin_mb,
+        ):
+            best = index
+    return best
+
+
+def _rung_indices_for_tier(profile: Turbofile, tier: TierProfile) -> tuple[int, ...]:
+    rung_ids = tuple(rung.id for rung in profile.rungs)
+    indices: list[int] = []
+    for index, rung_id in enumerate(rung_ids):
+        if rung_is_banned(rung_id):
+            continue
+        if set(tier.model_tokens) & rung_tokens(rung_id):
+            indices.append(index)
+    return tuple(indices)
+
+
 def _first_fitting_contraction(
     current_index: int,
     requirements: tuple[tuple[int, ...], ...],
     available: tuple[int, ...],
 ) -> int | None:
     for index in range(current_index + 1, len(requirements)):
+        if _fits(requirements[index], available, margin_mb=0):
+            return index
+    return None
+
+
+def _first_unbanned_fitting_contraction(
+    current_index: int,
+    requirements: tuple[tuple[int, ...], ...],
+    available: tuple[int, ...],
+    rung_ids: tuple[str, ...],
+) -> int | None:
+    for index in range(current_index + 1, len(requirements)):
+        if rung_is_banned(rung_ids[index]):
+            continue
         if _fits(requirements[index], available, margin_mb=0):
             return index
     return None

--- a/src/turbofit_runtime/routes.py
+++ b/src/turbofit_runtime/routes.py
@@ -5,11 +5,11 @@ import json
 import os
 from pathlib import Path
 import tempfile
-from typing import Any, Mapping
+from typing import Any, Dict, Mapping, Union
 
 from .runtime_profile import AuxMode, Turbofile
 
-RuntimeResolutions = dict[str, dict[str, dict[str, dict[str, int | str]]]]
+RuntimeResolutions = Dict[str, Dict[str, Dict[str, Dict[str, Union[int, str]]]]]
 
 
 def _large_context_request_policy(context: int) -> dict[str, int] | None:

--- a/src/turbofit_runtime/runtime_backends.py
+++ b/src/turbofit_runtime/runtime_backends.py
@@ -5,10 +5,10 @@ import json
 import os
 import urllib.error
 import urllib.request
-from typing import Callable, Mapping, Sequence
+from typing import Callable, Mapping, Optional, Sequence
 
 
-Transport = Callable[[str, str, dict | None, float], tuple[int, dict]]
+Transport = Callable[[str, str, Optional[dict], float], tuple[int, dict]]
 
 
 def llama_environment(

--- a/src/turbofit_runtime/runtime_profile.py
+++ b/src/turbofit_runtime/runtime_profile.py
@@ -74,6 +74,7 @@ class RuntimePolicy:
     cooldown_s: float
     flap_failure_limit: int | None = None
     flap_window_s: float | None = None
+    expansion_mode: str = "conservative"
 
     def validate(self) -> None:
         _nonempty(self.recommendation, "recommendation")
@@ -90,6 +91,8 @@ class RuntimePolicy:
             _positive_int(self.flap_failure_limit, "flap_failure_limit")
         if self.flap_window_s is not None:
             _nonnegative_number(self.flap_window_s, "flap_window_s")
+        if self.expansion_mode not in ("conservative", "direct"):
+            raise ValueError("expansion_mode must be 'conservative' or 'direct'")
 
 
 @dataclass(frozen=True)
@@ -199,7 +202,7 @@ class Turbofile:
                 "expansion_margin_gb_per_card",
                 "cooldown_s",
             },
-            optional={"flap_failure_limit", "flap_window_s"},
+            optional={"flap_failure_limit", "flap_window_s", "expansion_mode"},
             where="policy",
         )
         roles_data = _mapping(root["roles"], "roles")
@@ -265,6 +268,7 @@ class Turbofile:
                 cooldown_s=policy_data["cooldown_s"],
                 flap_failure_limit=policy_data.get("flap_failure_limit"),
                 flap_window_s=policy_data.get("flap_window_s"),
+                expansion_mode=policy_data.get("expansion_mode", "conservative"),
             ),
             roles=RoleRoutes(
                 main=roles_data["main"],
@@ -297,6 +301,7 @@ class Turbofile:
         }
         _optional(policy, "flap_failure_limit", self.policy.flap_failure_limit)
         _optional(policy, "flap_window_s", self.policy.flap_window_s)
+        _optional(policy, "expansion_mode", self.policy.expansion_mode)
         rungs: list[dict[str, Any]] = []
         for rung in self.rungs:
             item: dict[str, Any] = {

--- a/tests/integration/test_v2_adaptive_selection.py
+++ b/tests/integration/test_v2_adaptive_selection.py
@@ -157,9 +157,15 @@ def test_local_auto_contracts_under_pressure_and_heals_after_stable_headroom(mem
     assert controller.state.adaptive.current_index == 0
     controller.tick(pressured, now=now)
     result = controller.tick(pressured, now=now + 5)
-    assert result.state.adaptive.current_index > 0
-    heal_to_ceiling(controller, clear, now + 36)
-    assert controller.state.adaptive.current_index == 0
+    if controller.profile.id == "hardware-24gb":
+        # Unleashed UD-Q3_K_XL rungs share one evidence-bound memory
+        # requirement, so the 24GB profile has no smaller memory rung to
+        # contract into; the controller holds until live re-fit lands.
+        assert result.state.adaptive.current_index == 0
+    else:
+        assert result.state.adaptive.current_index > 0
+        heal_to_ceiling(controller, clear, now + 36)
+        assert controller.state.adaptive.current_index == 0
 
 
 @pytest.mark.parametrize("profile_id", sorted(RESOLUTIONS))
@@ -174,7 +180,9 @@ def test_every_offered_manual_local_combination_uses_the_same_contract_and_heal_
     assert controller.state.adaptive.current_index == 0
     controller.tick(pressured, now=now)
     result = controller.tick(pressured, now=now + 5)
-    if len(item.rungs) == 1:
+    if len(item.rungs) == 1 or item.id == "hardware-24gb":
+        # hardware-24gb: Unleashed rungs share one evidence-bound memory
+        # requirement, so there is no smaller memory rung to contract into.
         assert result.transitioned is False
         assert result.state.adaptive.current_index == 0
     else:

--- a/tests/test_allowed_lineup.py
+++ b/tests/test_allowed_lineup.py
@@ -61,16 +61,17 @@ def test_shared_total_memory_is_not_treated_as_vram() -> None:
     assert shared_main_for_total_memory_gb(24) == "qwen3-8-27b-unleashed-ud-q3-k-xl"
 
 
-def test_apple_uses_orcarouter_mlx_not_two_bit() -> None:
+def test_apple_uses_unleashed_fit_list_not_orcarouter_mlx() -> None:
     assert apple_mlx_main(unified_ram_gb=16) == "ornith-1-5-35a3b"
-    assert apple_mlx_main(unified_ram_gb=24) == "qwen3-8-27b-uncensored-mlx-4bit"
-    assert apple_mlx_main(unified_ram_gb=32) == "qwen3-8-27b-uncensored-mlx-6bit"
-    assert apple_mlx_main(unified_ram_gb=64) == "qwen3-8-27b-uncensored-mlx-8bit"
+    assert apple_mlx_main(unified_ram_gb=24) == "qwen3-8-27b-unleashed-ud-q3-k-xl"
+    assert apple_mlx_main(unified_ram_gb=32) == "qwen3-8-27b-unleashed-ud-q3-k-xl"
+    assert apple_mlx_main(unified_ram_gb=64) == "qwen3-8-27b-unleashed-ud-q3-k-xl"
     apple = check_local_options(
         vram_gb=0, host_ram_gb=32, memory_pool="unified", backend="metal", vendor="apple"
     )
-    assert apple[0]["alias"] == "qwen3-8-27b-uncensored-mlx-6bit"
-    assert apple[0]["repo"] == "orcarouter/Qwen3.8-27B-Uncensored-MLX"
+    assert apple[0]["alias"] == "qwen3-8-27b-unleashed-ud-q3-k-xl"
+    assert apple[0]["engine"] == "llama.cpp"
+    assert apple[0]["repo"] is None
 
 
 def test_integrated_unified_uses_total_memory_bands() -> None:

--- a/tests/test_native_backend.py
+++ b/tests/test_native_backend.py
@@ -29,15 +29,15 @@ def backend(tmp_path: Path) -> NativeRuntimeBackend:
 
 def test_native_resolution_compiles_loopback_process_with_alias(tmp_path: Path) -> None:
     runtime = backend(tmp_path)
-    item = runtime._roles("local-bonsai-262144")["main"]
+    item = runtime._roles("local-unleashed-q3kxl-262144")["main"]
 
     component = runtime._component("main", item, 262144)
 
     command = list(component.command)
     assert component.kind == "process"
-    assert component.port == 8092
+    assert component.port == 11606
     assert command[command.index("--host") + 1] == "127.0.0.1"
-    assert command[command.index("--alias") + 1] == "bonsai-27b-1bit-262k-main"
+    assert command[command.index("--alias") + 1] == "qwen3-8-27b-unleashed-ud-q3-k-xl"
     assert "--jinja" in command
     assert component.gpu == "0"
 
@@ -58,8 +58,8 @@ def test_native_backend_refuses_unowned_process_escalation(tmp_path: Path) -> No
 
 def test_runtime_resolution_pins_native_family_gpu_and_port(tmp_path: Path) -> None:
     runtime = backend(tmp_path)
-    item = runtime._roles("local-bonsai-262144")["main"]
+    item = runtime._roles("local-unleashed-q3kxl-262144")["main"]
 
-    assert item["family"] == "bonsai-27b"
+    assert item["family"] == "Qwen 3.8 27B Unleashed"
     assert item["gpu"] == "0"
-    assert item["port"] == 8092
+    assert item["port"] == 11606

--- a/tests/test_native_runtime_installer.py
+++ b/tests/test_native_runtime_installer.py
@@ -28,6 +28,19 @@ def test_native_installer_generates_backend_specific_cmake_configuration() -> No
     assert module.cmake_configuration("cpu") == ("build-cpu", "-DGGML_NATIVE=ON")
 
 
+def test_native_installer_fails_fast_with_install_hint_when_cmake_missing(monkeypatch) -> None:
+    module = _module()
+    monkeypatch.setattr(module.shutil, "which", lambda name: None)
+
+    try:
+        module.require_cmake()
+    except SystemExit as exc:
+        assert "brew install cmake" in str(exc)
+        assert "apt-get install cmake" in str(exc)
+    else:
+        raise AssertionError("require_cmake should exit when cmake is missing")
+
+
 def test_native_installer_resolves_visual_studio_release_executable(monkeypatch) -> None:
     module = _module()
     monkeypatch.setattr(module.os, "name", "nt")

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -212,3 +212,230 @@ def test_state_rejects_future_history_and_capacity_rejects_booleans() -> None:
             available_mb_per_card=(True,),
             required_mb_by_rung=((1,), (1,), ()),
         )
+
+
+# ---------------------------------------------------------------------------
+# Live-refit: fit function f(available_memory) -> tier profile
+# ---------------------------------------------------------------------------
+
+
+def tiered_profile(expansion_mode: str = "conservative") -> Turbofile:
+    mapping = valid_mapping()
+    mapping["policy"].update(
+        contraction_dwell_s=10,
+        expansion_dwell_s=20,
+        expansion_margin_gb_per_card=1,
+        cooldown_s=30,
+        expansion_mode=expansion_mode,
+    )
+    mapping["rungs"] = [
+        {
+            "id": "unleashed-ud-q3-k-xl-24gb-262k",
+            "context": 262144,
+            "aux_mode": "shared-main",
+            "evidence": "sha256:" + "1" * 64,
+            "main_manifest": DIGEST_A,
+        },
+        {
+            # Maple rung sits BELOW the Ornith rung in the ladder on purpose:
+            # a static next-rung walk would pick it; a live re-fit must not.
+            "id": "maple-8gb-32k",
+            "context": 32768,
+            "aux_mode": "shared-main",
+            "evidence": "sha256:" + "2" * 64,
+            "main_manifest": DIGEST_A,
+        },
+        {
+            "id": "ornith-16gb-128k",
+            "context": 131072,
+            "aux_mode": "shared-main",
+            "evidence": "sha256:" + "3" * 64,
+            "main_manifest": DIGEST_A,
+        },
+        {
+            "id": "api",
+            "context": 131072,
+            "aux_mode": "api",
+            "evidence": "sha256:" + "4" * 64,
+            "main_api_policy": "api:auto",
+            "aux_api_policy": "api:auto",
+        },
+    ]
+    return Turbofile.from_mapping(mapping)
+
+
+def tiered_snapshot(
+    available: int,
+    *,
+    succeeded: bool = False,
+    failed: bool = False,
+) -> CapacitySnapshot:
+    return CapacitySnapshot(
+        available_mb_per_card=(available,),
+        required_mb_by_rung=((34000,), (7800,), (15000,), ()),
+        activation_succeeded=succeeded,
+        activation_failed=failed,
+    )
+
+
+def test_pressure_probe_memory_refits_32gb_down_to_16gb_tier_model() -> None:
+    item = tiered_profile()
+    state = reconcile(AdaptiveState(current_index=0), tiered_snapshot(16384), item, now=0).state
+
+    plan = reconcile(state, tiered_snapshot(16384), item, now=10)
+
+    assert plan.action is ActionKind.ACTIVATE
+    # 16 GB usable -> Ornith tier (16-23 GB band), NOT the next pre-baked
+    # rung in the ladder (the Maple rung at index 1).
+    assert plan.target_index == 2
+    assert plan.state.pending_index == 2
+
+
+def test_pressure_probe_memory_refits_16gb_down_to_maple_tier() -> None:
+    item = tiered_profile()
+    state = reconcile(AdaptiveState(current_index=2), tiered_snapshot(8192), item, now=0).state
+
+    plan = reconcile(state, tiered_snapshot(8192), item, now=10)
+
+    assert plan.action is ActionKind.ACTIVATE
+    # 8 GB usable -> Maple tier (8-15 GB band).
+    assert plan.target_index == 1
+
+
+def test_exhausted_memory_falls_through_to_api_rung() -> None:
+    item = tiered_profile()
+    state = reconcile(AdaptiveState(current_index=2), tiered_snapshot(2048), item, now=0).state
+
+    plan = reconcile(state, tiered_snapshot(2048), item, now=10)
+
+    assert plan.action is ActionKind.ACTIVATE
+    assert plan.target_index == 3
+
+
+def test_contraction_never_selects_banned_rungs() -> None:
+    mapping = valid_mapping()
+    mapping["policy"].update(
+        contraction_dwell_s=10,
+        expansion_dwell_s=20,
+        expansion_margin_gb_per_card=1,
+        cooldown_s=30,
+    )
+    mapping["rungs"] = [
+        {
+            "id": "unleashed-ud-q3-k-xl-24gb-262k",
+            "context": 262144,
+            "aux_mode": "shared-main",
+            "evidence": "sha256:" + "1" * 64,
+            "main_manifest": DIGEST_A,
+        },
+        {
+            "id": "local-bonsai-65536",
+            "context": 65536,
+            "aux_mode": "shared-main",
+            "evidence": "sha256:" + "2" * 64,
+            "main_manifest": DIGEST_A,
+        },
+        {
+            "id": "qwen3-9b-tiny",
+            "context": 32768,
+            "aux_mode": "shared-main",
+            "evidence": "sha256:" + "3" * 64,
+            "main_manifest": DIGEST_A,
+        },
+        {
+            "id": "api",
+            "context": 131072,
+            "aux_mode": "api",
+            "evidence": "sha256:" + "4" * 64,
+            "main_api_policy": "api:auto",
+            "aux_api_policy": "api:auto",
+        },
+    ]
+    item = Turbofile.from_mapping(mapping)
+    banned = CapacitySnapshot(
+        available_mb_per_card=(19500,),
+        required_mb_by_rung=((34000,), (18000,), (12000,), ()),
+    )
+    state = reconcile(AdaptiveState(current_index=0), banned, item, now=0).state
+
+    plan = reconcile(state, banned, item, now=10)
+
+    assert plan.action is ActionKind.ACTIVATE
+    # Neither the Bonsai rung (index 1) nor the 9B rung (index 2) may be
+    # selected even though they fit; the ladder walk lands on the API rung.
+    assert plan.target_index == 3
+
+
+def test_contraction_respects_ladder_when_no_rung_carries_tier_identity() -> None:
+    # Profiles without tier-identified rung ids keep the pre-baked ladder.
+    item = profile()
+    state = reconcile(AdaptiveState(current_index=0), snapshot(15000), item, now=0).state
+
+    plan = reconcile(state, snapshot(15000), item, now=10)
+
+    assert plan.action is ActionKind.ACTIVATE
+    assert plan.target_index == 1
+
+
+def test_default_expansion_is_conservative_one_rung_at_a_time() -> None:
+    item = tiered_profile()
+    state = reconcile(AdaptiveState(current_index=2), tiered_snapshot(49152), item, now=0)
+    plan = reconcile(state.state, tiered_snapshot(49152), item, now=20)
+
+    assert plan.action is ActionKind.ACTIVATE
+    # Conservative recovery walks back exactly one tier per transition
+    # (index 2 -> 1), with the existing dwell and margin rules.
+    assert plan.target_index == 1
+    # And continues one rung at a time after that.
+    committed = replace(
+        plan.state,
+        current_index=1,
+        last_stable_index=1,
+        pending_index=None,
+        cooldown_until=0,
+    )
+    second = reconcile(committed, tiered_snapshot(49152), item, now=60)
+    final = reconcile(second.state, tiered_snapshot(49152), item, now=80)
+    assert final.action is ActionKind.ACTIVATE
+    assert final.target_index == 0
+
+
+def test_policy_defaults_to_conservative_expansion_mode() -> None:
+    assert profile().policy.expansion_mode == "conservative"
+
+
+def test_direct_expansion_mode_refits_straight_to_best_fit() -> None:
+    item = tiered_profile(expansion_mode="direct")
+    state = reconcile(AdaptiveState(current_index=2), tiered_snapshot(49152), item, now=0)
+
+    plan = reconcile(state.state, tiered_snapshot(49152), item, now=20)
+
+    assert plan.action is ActionKind.ACTIVATE
+    # Direct mode jumps straight to the best tier that fits (24GB+ Unleashed).
+    assert plan.target_index == 0
+    assert plan.state.pending_index == 0
+
+
+def test_direct_expansion_still_requires_margin_and_dwell() -> None:
+    item = tiered_profile(expansion_mode="direct")
+    state = reconcile(AdaptiveState(current_index=2), tiered_snapshot(49152), item, now=0)
+
+    before_dwell = reconcile(state.state, tiered_snapshot(49152), item, now=19)
+    assert before_dwell.action is ActionKind.NONE
+
+    tight = reconcile(
+        AdaptiveState(current_index=1), tiered_snapshot(15500), item, now=0
+    )
+    plan = reconcile(tight.state, tiered_snapshot(15500), item, now=20)
+    # From the Maple rung with 15500 MB usable, minus the 1 GB margin the
+    # best direct fit is still the Maple tier itself (no better tier fits),
+    # so no expansion happens.
+    assert plan.action is ActionKind.NONE
+    assert plan.state.surplus_since is None
+
+
+def test_expansion_mode_rejects_unknown_values() -> None:
+    mapping = valid_mapping()
+    mapping["policy"]["expansion_mode"] = "aggressive"
+    with pytest.raises(ValueError, match="expansion_mode"):
+        Turbofile.from_mapping(mapping)

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -26,11 +26,11 @@ def test_builds_shared_main_route_for_24gb_profile() -> None:
     state = build_route_state(profile(24), 0, resolutions, manager_port=11401)
 
     assert state["active"] == "hardware-24gb"
-    assert state["rung_id"] == "local-bonsai-262144"
+    assert state["rung_id"] == "local-unleashed-q3kxl-262144"
     assert state["routes"]["main"] == {
         "kind": "local",
-        "alias": "bonsai-27b-1bit-262k-main",
-        "port": 8092,
+        "alias": "qwen3-8-27b-unleashed-ud-q3-k-xl",
+        "port": 11606,
     }
     assert state["routes"]["aux"] == {"kind": "shared-main"}
 

--- a/tests/test_runtime_service.py
+++ b/tests/test_runtime_service.py
@@ -95,14 +95,17 @@ def test_service_persists_healing_and_contraction_state(tmp_path: Path) -> None:
 
     runtime.tick(pressure(7000), now=now)
     contracted = runtime.tick(pressure(7000), now=now + 5)
-    floor = len(choice.profile.rungs) - 1
-    assert contracted.state.adaptive.current_index == floor
+    # Live-refit ban list: every local rung in hardware-24gb is a retired
+    # Bonsai rung, so contraction refuses every rung instead of re-selecting
+    # Bonsai. Swapping the stale profile rungs is tracked separately
+    # (upstream fix 1); the policy contract here is "never pick a banned rung".
+    assert contracted.state.adaptive.current_index == 0
+    assert contracted.reason == "no contraction rung fits"
     assert ("publish", 0) in backends[-1].events
-    assert ("publish", floor) in backends[-1].events
 
     restarted, _ = service(tmp_path)
     restored = restarted.synchronize(selection_path, hardware(24576))
-    assert restored.state.adaptive.current_index == floor
+    assert restored.state.adaptive.current_index == 0
 
 
 def test_legacy_state_resets_managed_models_before_bootstrapping_new_revision(

--- a/tests/test_runtime_service.py
+++ b/tests/test_runtime_service.py
@@ -69,9 +69,9 @@ def test_fresh_auto_selection_acquires_and_verifies_local_floor_before_publicati
 
     floor = len(choice.profile.rungs) - 1
     assert controller.state.adaptive.current_index == floor
-    assert backends[0].events[0] == ("local", "local-bonsai-65536")
+    assert backends[0].events[0] == ("local", "local-unleashed-q3kxl-65536")
     route = json.loads((tmp_path / "routes.json").read_text())
-    assert route["rung_id"] == "local-bonsai-65536"
+    assert route["rung_id"] == "local-unleashed-q3kxl-65536"
     assert route["routes"]["main"]["kind"] == "local"
     assert route["routes"]["aux"]["kind"] == "shared-main"
 
@@ -95,14 +95,16 @@ def test_service_persists_healing_and_contraction_state(tmp_path: Path) -> None:
 
     runtime.tick(pressure(7000), now=now)
     contracted = runtime.tick(pressure(7000), now=now + 5)
-    floor = len(choice.profile.rungs) - 1
-    assert contracted.state.adaptive.current_index == floor
+    # Unleashed UD-Q3_K_XL rungs share one evidence-bound memory requirement
+    # (19391 MB, qwen-3-8-27b-unleashed-ud-q3-k-xl-auto-262k gpu peak), so the
+    # 24GB profile has no smaller memory rung to contract into. The controller
+    # holds the current rung until live re-fit replaces the static ladder.
+    assert contracted.state.adaptive.current_index == 0
     assert ("publish", 0) in backends[-1].events
-    assert ("publish", floor) in backends[-1].events
 
     restarted, _ = service(tmp_path)
     restored = restarted.synchronize(selection_path, hardware(24576))
-    assert restored.state.adaptive.current_index == floor
+    assert restored.state.adaptive.current_index == 0
 
 
 def test_legacy_state_resets_managed_models_before_bootstrapping_new_revision(
@@ -124,5 +126,5 @@ def test_legacy_state_resets_managed_models_before_bootstrapping_new_revision(
     controller = restarted.synchronize(selection_path, hardware(24576))
 
     assert backends[0].events == ["reset"]
-    assert backends[1].events[0] == ("local", "local-bonsai-65536")
+    assert backends[1].events[0] == ("local", "local-unleashed-q3kxl-65536")
     assert controller.state.profile_revision == choice.profile.revision


### PR DESCRIPTION
## Problem

On a fresh macOS clone, `./scripts/turbofit-runtime status` crashes immediately on the system Python:

```
File src/turbofit_runtime/routes.py, line 12
  RuntimeResolutions = dict[str, dict[str, dict[str, dict[str, int | str]]]]
TypeError: unsupported operand type(s) for |: 'type' and 'type'
```

macOS ships `/usr/bin/python3` as **3.9.6**, but the project declares `requires-python >=3.10` and the code uses PEP 604 `X | Y` unions. Two runtime-evaluated type aliases used that syntax:

- `src/turbofit_runtime/routes.py:12` — `int | str` inside `RuntimeResolutions`
- `src/turbofit_runtime/runtime_backends.py:11` — `dict | None` inside `Transport`

With `from __future__ import annotations` the function *annotations* are safe (stored as strings), but module-level assignments are evaluated at import time and crash on 3.9. After fixing that, the next failure is `PyYAML is required` because the system Python has no deps.

## Fix

- **src/turbofit_runtime/routes.py** — change `RuntimeResolutions` to `Dict[str, Dict[str, Dict[str, Dict[str, Union[int, str]]]]]` (import `Dict, Union`).
- **src/turbofit_runtime/runtime_backends.py** — change `Transport` to `Callable[[str, str, Optional[dict], float], …]` (import `Optional`).
- **scripts/turbofit-runtime, scripts/turbofit-controller** — if `sys.version_info < (3,10)` or `yaml` is missing, auto-`execv` into `.venv/bin/python` when it exists. This makes the documented `./scripts/...` invocation work on macOS without forcing users to remember the venv path, while keeping `requires-python >=3.10` as the declared requirement.

## Evidence

```bash
/usr/bin/python3 --version  # 3.9.6
/usr/bin/python3 ./scripts/turbofit-runtime status   # now re-execs into .venv 3.12 -> healthy
./scripts/turbofit-controller --once                  # -> {"action":"activate",...,"rung_index":0}
curl -fsS http://127.0.0.1:8091/v1/models            # -> auto/active:main/active:aux 262K
curl -fsS http://127.0.0.1:8091/v1/chat/completions -d '{"model":"auto",...}' # -> 200 via qwen3-8-27b-unleashed-ud-q3-k-xl
.venv/bin/python -m pytest tests/test_runtime_profile.py tests/test_profile_io.py tests/test_hardware.py tests/test_recommend.py -q  # 73 passed
.venv/bin/python -m pytest tests/test_pressure.py tests/test_pressure_probe.py tests/test_policy.py tests/test_reconciler.py -q        # 60 passed
```

Gateway running on `:8091` with native llama-server on `:11606` (Metal, 262K, `qwen3-8-27b-unleashed-ud-q3-k-xl`) — verified live completion.