### PR TITLE
Add managed Apple MLX runtime for Qwen 3.8 27B

### DIFF
--- a/desktop/plugin.js
+++ b/desktop/plugin.js
@@ -587,7 +587,7 @@ function TurbofitPage() {
         }),
         jsxs('label', { className: 'flex items-center gap-2', children: [
           jsx('input', { type: 'checkbox', checked: installNative, onChange: (event) => setInstallNative(event.target.checked) }),
-          'Install or verify the native adaptive runtime',
+          'Install and activate the native runtime (downloads the selected model and starts local processes)',
         ] }),
         jsxs('label', { className: 'flex items-center gap-2', children: [
           jsx('input', { type: 'checkbox', checked: installFreeToken, onChange: (event) => setInstallFreeToken(event.target.checked) }),

--- a/distribution.yaml
+++ b/distribution.yaml
@@ -59,6 +59,9 @@ distribution_owned:
   - scripts/build-promo-video
   - scripts/download-models.py
   - scripts/download-artifacts
+  - scripts/install-mlx-runtime
+  - scripts/turbofit-gateway-runtime
+  - scripts/turbofit-mlx-runtime
   - scripts/install-dspark-runtime
   - scripts/install-lemonade-runtime
   - scripts/install-macos-native-service
@@ -79,11 +82,13 @@ distribution_owned:
 
   - references/model-recipes.json
   - references/artifact-manifest.json
+  - references/python-runtimes.json
   - references/hardware-tier-tournaments.json
   - references/auxiliary-tier-recommendations.json
   - references/intelligence-scores.json
   - references/external-benchmarks.md
 
-# Installation does not start launchers, watchers, or modify provider credentials.
-# Runtime activation remains an explicit Turbofile selection.
+# Plugin installation alone does not start launchers, watchers, or modify provider
+# credentials. Explicit install_native setup may install a selected model and start
+# its loopback runtime and provider gateway.
 post_install: []

--- a/plugin_tools.py
+++ b/plugin_tools.py
@@ -307,12 +307,101 @@ def install_native_runtime(backend: str = "auto") -> dict[str, Any]:
     return payload
 
 
-def recommended_artifact_families(usable_memory_mb: int | None = None) -> list[str]:
-    """Auto-chain families for this machine, plus default Ornith auxiliary."""
-    if usable_memory_mb is None:
+def probe_hardware():
+    """Profile-local seam for deterministic setup tests and platform routing."""
+    from turbofit_runtime.hardware import probe_hardware as probe
+
+    return probe()
+
+
+def _apple_mlx_hardware(hardware) -> bool:
+    devices = tuple(getattr(hardware, "devices", ()) or ())
+    return any(
+        getattr(device, "vendor", "") == "apple"
+        or getattr(device, "backend", "") == "metal"
+        for device in devices
+    )
+
+
+def install_mlx_runtime() -> dict[str, Any]:
+    script = PLUGIN_ROOT / "scripts" / "install-mlx-runtime"
+    result = subprocess.run(
+        [str(script), "--json"],
+        text=True,
+        capture_output=True,
+        timeout=1800,
+        check=False,
+    )
+    try:
+        payload = json.loads(result.stdout or result.stderr)
+    except ValueError as exc:
+        raise RuntimeError((result.stdout or result.stderr).strip() or "MLX install failed") from exc
+    if result.returncode:
+        raise RuntimeError(payload.get("error") or "MLX install failed")
+    return payload
+
+
+def activate_apple_mlx_stack() -> dict[str, Any]:
+    model_script = PLUGIN_ROOT / "scripts" / "turbofit-mlx-runtime"
+    gateway_script = PLUGIN_ROOT / "scripts" / "turbofit-gateway-runtime"
+    model = subprocess.run(
+        [str(model_script), "start"],
+        text=True,
+        capture_output=True,
+        timeout=1200,
+        check=False,
+    )
+    if model.returncode:
+        raise RuntimeError((model.stderr or model.stdout or "MLX runtime failed").strip())
+    gateway = subprocess.run(
+        [str(gateway_script), "start"],
+        text=True,
+        capture_output=True,
+        timeout=180,
+        check=False,
+    )
+    if gateway.returncode:
+        subprocess.run([str(model_script), "stop"], check=False, timeout=60)
+        raise RuntimeError((gateway.stderr or gateway.stdout or "gateway failed").strip())
+    return {
+        "ok": True,
+        "engine": "mlx",
+        "model": json.loads(model.stdout),
+        "gateway": json.loads(gateway.stdout),
+    }
+
+
+def recommended_artifact_families(
+    usable_memory_mb: int | None = None,
+    *,
+    hardware=None,
+) -> list[str]:
+    """Return artifacts for the machine's actual memory pool and engine lane."""
+    if hardware is None and usable_memory_mb is None:
         from turbofit_runtime.hardware import probe_hardware
 
-        usable_memory_mb = int(probe_hardware().total_usable_memory_mb)
+        hardware = probe_hardware()
+    if hardware is not None:
+        devices = tuple(getattr(hardware, "devices", ()) or ())
+        backend = str(getattr(devices[0], "backend", "") if devices else "")
+        vendor = str(getattr(devices[0], "vendor", "") if devices else "")
+        if backend == "metal" or vendor == "apple":
+            from turbofit_runtime.allowed_lineup import check_local_options
+
+            options = check_local_options(
+                vram_gb=0,
+                host_ram_gb=float(hardware.system_ram_mb) / 1024,
+                memory_pool="unified",
+                backend=backend or "metal",
+                vendor=vendor or "apple",
+            )
+            mains = [str(item["alias"]) for item in options if item.get("role") == "main"]
+            if not mains:
+                raise RuntimeError("Apple MLX recommendation produced no main model")
+            return [mains[0]]
+        usable_memory_mb = int(hardware.total_usable_memory_mb)
+    if usable_memory_mb is None:
+        raise ValueError("usable memory or hardware is required")
     if usable_memory_mb < 16 * 1024:
         main = "maple-preview-tq2"
     elif usable_memory_mb < 24 * 1024:
@@ -1076,13 +1165,27 @@ def apply_configuration(
     from hermes_cli.config import load_config, save_config
 
     with _CONFIG_LOCK:
+        hardware = probe_hardware()
+        apple_hardware = profile == "auto" and _apple_mlx_hardware(hardware)
+        families = recommended_artifact_families(hardware=hardware) if apple_hardware else None
+        apple_family = families[0] if families else None
+        apple_mlx = apple_family == "qwen3-8-27b-uncensored-mlx-8bit"
+        if apple_family and "-mlx-" in apple_family and not apple_mlx:
+            raise RuntimeError(
+                f"managed Apple MLX artifact is not pinned for {apple_family}; setup is blocked"
+            )
+        if apple_mlx and not install_native:
+            raise ValueError(
+                "Apple MLX auto activation requires install_native=true because it installs "
+                "the pinned runtime and starts loopback model and gateway processes"
+            )
         sirvir = install_sirvir_profile() if install_sirvir else None
         desktop = install_desktop_plugin() if install_desktop else None
         lemonade = install_lemonade_runtime() if install_lemonade else None
-        native = install_native_runtime() if install_native else None
+        native = install_native_runtime() if install_native and not apple_mlx else None
         freetoken = install_freetoken_runtime() if install_freetoken else None
-        models = ensure_recommended_models()
-        selected = select_profile(profile) if profile else None
+        models = ensure_recommended_models(families=families) if families else ensure_recommended_models()
+        mlx_runtime = install_mlx_runtime() if apple_mlx else None
         publication = (
             publish_tailnet(
                 dashboard_local_port=dashboard_local_port,
@@ -1094,8 +1197,9 @@ def apply_configuration(
             else None
         )
         effective_base_url = publication["provider_base_url"] if publication else base_url
+        original_config = load_config()
         configured = configure_hermes(
-            load_config(),
+            original_config,
             primary=primary,
             fallback=fallback,
             fallback_chain=list(NOUS_FREE_FALLBACK_CHAIN) if fallback_chain is None else fallback_chain,
@@ -1110,6 +1214,15 @@ def apply_configuration(
                 catalog=MultimodalCatalog.load(MULTIMODAL_CATALOG),
             )
         save_config(configured, merge_existing=False)
+        try:
+            selected = (
+                activate_apple_mlx_stack()
+                if apple_mlx
+                else (select_profile(profile) if profile else None)
+            )
+        except Exception:
+            save_config(original_config, merge_existing=False)
+            raise
     return {
         "ok": True,
         "configured": True,
@@ -1119,6 +1232,7 @@ def apply_configuration(
         "desktop_plugin": desktop,
         "lemonade": lemonade,
         "native_runtime": native,
+        "mlx_runtime": mlx_runtime,
         "freetoken_runtime": freetoken,
         "models": models,
         "restart_required": True,

--- a/references/artifact-manifest.json
+++ b/references/artifact-manifest.json
@@ -500,6 +500,159 @@
       "path": "maple-tq2_0.gguf",
       "sha256": "09d219202562dbd17722dc8e3273527a021182ab7f892c2a06aac459a8f3a090",
       "size_bytes": 5454482432
+    },
+    {
+      "destination": "Qwen3.8-27B-Uncensored-MLX/8-bit/README.md",
+      "families": ["qwen3-8-27b-uncensored-mlx-8bit"],
+      "repo_id": "orcarouter/Qwen3.8-27B-Uncensored-MLX",
+      "revision": "b4603df5fd2a51e7fed2560ee7090caa4e13e4b7",
+      "path": "8-bit/README.md",
+      "sha256": "9a272b5949a803ab6eadf0703706dab183229952e2b374501d1069d0f6d16557",
+      "size_bytes": 84
+    },
+    {
+      "destination": "Qwen3.8-27B-Uncensored-MLX/8-bit/chat_template.jinja",
+      "families": ["qwen3-8-27b-uncensored-mlx-8bit"],
+      "repo_id": "orcarouter/Qwen3.8-27B-Uncensored-MLX",
+      "revision": "b4603df5fd2a51e7fed2560ee7090caa4e13e4b7",
+      "path": "8-bit/chat_template.jinja",
+      "sha256": "c3cf9e34abf4f9e36c2d72165aa9c132d3e2a725b6c2586aaa3a8af9d7a81041",
+      "size_bytes": 8952
+    },
+    {
+      "destination": "Qwen3.8-27B-Uncensored-MLX/8-bit/config.json",
+      "families": ["qwen3-8-27b-uncensored-mlx-8bit"],
+      "repo_id": "orcarouter/Qwen3.8-27B-Uncensored-MLX",
+      "revision": "b4603df5fd2a51e7fed2560ee7090caa4e13e4b7",
+      "path": "8-bit/config.json",
+      "sha256": "10ee84e6bb4f99d09d3166ab85f92e5b313b8bdb9117f5db694c598173cd303b",
+      "size_bytes": 5187
+    },
+    {
+      "destination": "Qwen3.8-27B-Uncensored-MLX/8-bit/generation_config.json",
+      "families": ["qwen3-8-27b-uncensored-mlx-8bit"],
+      "repo_id": "orcarouter/Qwen3.8-27B-Uncensored-MLX",
+      "revision": "b4603df5fd2a51e7fed2560ee7090caa4e13e4b7",
+      "path": "8-bit/generation_config.json",
+      "sha256": "e70c136c1b78ddc1fb0905bac8e733a4dc448d4f852a5dd75143fffc70be550e",
+      "size_bytes": 202
+    },
+    {
+      "destination": "Qwen3.8-27B-Uncensored-MLX/8-bit/model-00001-of-00006.safetensors",
+      "families": ["qwen3-8-27b-uncensored-mlx-8bit"],
+      "repo_id": "orcarouter/Qwen3.8-27B-Uncensored-MLX",
+      "revision": "b4603df5fd2a51e7fed2560ee7090caa4e13e4b7",
+      "path": "8-bit/model-00001-of-00006.safetensors",
+      "sha256": "d8f01eded64ecd012b90a8e1375433a5ec49cd1acadb77c2ed5f8ce833af528e",
+      "size_bytes": 5317707349
+    },
+    {
+      "destination": "Qwen3.8-27B-Uncensored-MLX/8-bit/model-00002-of-00006.safetensors",
+      "families": ["qwen3-8-27b-uncensored-mlx-8bit"],
+      "repo_id": "orcarouter/Qwen3.8-27B-Uncensored-MLX",
+      "revision": "b4603df5fd2a51e7fed2560ee7090caa4e13e4b7",
+      "path": "8-bit/model-00002-of-00006.safetensors",
+      "sha256": "e90b3f8eadb473ce46d60f231d7a50f0386d4e6dcb92907cd7c99f1e75e33573",
+      "size_bytes": 5354102528
+    },
+    {
+      "destination": "Qwen3.8-27B-Uncensored-MLX/8-bit/model-00003-of-00006.safetensors",
+      "families": ["qwen3-8-27b-uncensored-mlx-8bit"],
+      "repo_id": "orcarouter/Qwen3.8-27B-Uncensored-MLX",
+      "revision": "b4603df5fd2a51e7fed2560ee7090caa4e13e4b7",
+      "path": "8-bit/model-00003-of-00006.safetensors",
+      "sha256": "1fc349c8f9411680471dd5c0f6e586958feb9cc67d7c020ed459423b7b6ea050",
+      "size_bytes": 5354184654
+    },
+    {
+      "destination": "Qwen3.8-27B-Uncensored-MLX/8-bit/model-00004-of-00006.safetensors",
+      "families": ["qwen3-8-27b-uncensored-mlx-8bit"],
+      "repo_id": "orcarouter/Qwen3.8-27B-Uncensored-MLX",
+      "revision": "b4603df5fd2a51e7fed2560ee7090caa4e13e4b7",
+      "path": "8-bit/model-00004-of-00006.safetensors",
+      "sha256": "86b4fe4b4a85620254875b52575f5a459f83f0ead952c362b9800937a2e9dba9",
+      "size_bytes": 5337309675
+    },
+    {
+      "destination": "Qwen3.8-27B-Uncensored-MLX/8-bit/model-00005-of-00006.safetensors",
+      "families": ["qwen3-8-27b-uncensored-mlx-8bit"],
+      "repo_id": "orcarouter/Qwen3.8-27B-Uncensored-MLX",
+      "revision": "b4603df5fd2a51e7fed2560ee7090caa4e13e4b7",
+      "path": "8-bit/model-00005-of-00006.safetensors",
+      "sha256": "215aa22dc0d42e96283ae624b48c6ae82173999a6ff137c575f07f825ee53975",
+      "size_bytes": 5292848520
+    },
+    {
+      "destination": "Qwen3.8-27B-Uncensored-MLX/8-bit/model-00006-of-00006.safetensors",
+      "families": ["qwen3-8-27b-uncensored-mlx-8bit"],
+      "repo_id": "orcarouter/Qwen3.8-27B-Uncensored-MLX",
+      "revision": "b4603df5fd2a51e7fed2560ee7090caa4e13e4b7",
+      "path": "8-bit/model-00006-of-00006.safetensors",
+      "sha256": "0c7e1d9fb971cf6eaea638ee8d48661abc85ed822e34f405e334b8c1ef910ff6",
+      "size_bytes": 2845065535
+    },
+    {
+      "destination": "Qwen3.8-27B-Uncensored-MLX/8-bit/model.safetensors.index.json",
+      "families": ["qwen3-8-27b-uncensored-mlx-8bit"],
+      "repo_id": "orcarouter/Qwen3.8-27B-Uncensored-MLX",
+      "revision": "b4603df5fd2a51e7fed2560ee7090caa4e13e4b7",
+      "path": "8-bit/model.safetensors.index.json",
+      "sha256": "4301ca600788afb2a45c0aa367140d6144ecf617d0a51a8187fc6755d65301f8",
+      "size_bytes": 218281
+    },
+    {
+      "destination": "Qwen3.8-27B-Uncensored-MLX/8-bit/preprocessor_config.json",
+      "families": ["qwen3-8-27b-uncensored-mlx-8bit"],
+      "repo_id": "orcarouter/Qwen3.8-27B-Uncensored-MLX",
+      "revision": "b4603df5fd2a51e7fed2560ee7090caa4e13e4b7",
+      "path": "8-bit/preprocessor_config.json",
+      "sha256": "27225450ac9c6529872ee1924fcb0962ff5634834f817040f444118116f4e516",
+      "size_bytes": 390
+    },
+    {
+      "destination": "Qwen3.8-27B-Uncensored-MLX/8-bit/processor_config.json",
+      "families": ["qwen3-8-27b-uncensored-mlx-8bit"],
+      "repo_id": "orcarouter/Qwen3.8-27B-Uncensored-MLX",
+      "revision": "b4603df5fd2a51e7fed2560ee7090caa4e13e4b7",
+      "path": "8-bit/processor_config.json",
+      "sha256": "45fc17c8dd2474af6b493b52483c26c0584b0082d368c480f9fa611e73070040",
+      "size_bytes": 991
+    },
+    {
+      "destination": "Qwen3.8-27B-Uncensored-MLX/8-bit/tokenizer.json",
+      "families": ["qwen3-8-27b-uncensored-mlx-8bit"],
+      "repo_id": "orcarouter/Qwen3.8-27B-Uncensored-MLX",
+      "revision": "b4603df5fd2a51e7fed2560ee7090caa4e13e4b7",
+      "path": "8-bit/tokenizer.json",
+      "sha256": "06b9509352d2af50381ab2247e083b80d32d5c0aba91c272ca9ff729b6a0e523",
+      "size_bytes": 19989325
+    },
+    {
+      "destination": "Qwen3.8-27B-Uncensored-MLX/8-bit/tokenizer_config.json",
+      "families": ["qwen3-8-27b-uncensored-mlx-8bit"],
+      "repo_id": "orcarouter/Qwen3.8-27B-Uncensored-MLX",
+      "revision": "b4603df5fd2a51e7fed2560ee7090caa4e13e4b7",
+      "path": "8-bit/tokenizer_config.json",
+      "sha256": "792fa3f0cb88b111e54ef3134c873531008c4df471d108da17903426e308aa7b",
+      "size_bytes": 1165
+    },
+    {
+      "destination": "Qwen3.8-27B-Uncensored-MLX/8-bit/video_preprocessor_config.json",
+      "families": ["qwen3-8-27b-uncensored-mlx-8bit"],
+      "repo_id": "orcarouter/Qwen3.8-27B-Uncensored-MLX",
+      "revision": "b4603df5fd2a51e7fed2560ee7090caa4e13e4b7",
+      "path": "8-bit/video_preprocessor_config.json",
+      "sha256": "7768af27c1fafa9cc9011c1dc20067e03f8915e03b63504550e11d5066986d13",
+      "size_bytes": 385
+    },
+    {
+      "destination": "Qwen3.8-27B-Uncensored-MLX/8-bit/vocab.json",
+      "families": ["qwen3-8-27b-uncensored-mlx-8bit"],
+      "repo_id": "orcarouter/Qwen3.8-27B-Uncensored-MLX",
+      "revision": "b4603df5fd2a51e7fed2560ee7090caa4e13e4b7",
+      "path": "8-bit/vocab.json",
+      "sha256": "ce99b4cb2983d118806ce0a8b777a35b093e2000a503ebde25853284c9dfa003",
+      "size_bytes": 6722759
     }
   ]
 }

--- a/references/python-runtimes.json
+++ b/references/python-runtimes.json
@@ -1,0 +1,14 @@
+{
+  "schema": "turbofit.python-runtimes/v1",
+  "runtimes": {
+    "mlx-lm": {
+      "version": "0.31.3",
+      "packages": {
+        "mlx": "mlx==0.32.2",
+        "mlx-lm": "mlx-lm==0.31.3"
+      },
+      "platforms": ["darwin-arm64"],
+      "entrypoint": "python -m mlx_lm server"
+    }
+  }
+}

--- a/references/results/apple-m5-max-generic-mlx-20260830.json
+++ b/references/results/apple-m5-max-generic-mlx-20260830.json
@@ -1,0 +1,72 @@
+{
+  "schema": "turbofit.apple-runtime-evidence/v1",
+  "recorded_at": "2026-08-30T21:10:45Z",
+  "tested_turbofit_commit": "98b45598785c4ca8efe5a5d5ea0835782f4ee007",
+  "classification": "measured",
+  "hardware": {
+    "model": "MacBook Pro",
+    "chip": "Apple M5 Max",
+    "architecture": "arm64",
+    "system_memory_gib": 128,
+    "accelerator": "Apple GPU",
+    "accelerator_memory_kind": "unified",
+    "os": "macOS 26.6.1"
+  },
+  "artifact": {
+    "family": "qwen3-8-27b-uncensored-mlx-8bit",
+    "repository": "orcarouter/Qwen3.8-27B-Uncensored-MLX",
+    "revision": "b4603df5fd2a51e7fed2560ee7090caa4e13e4b7",
+    "variant": "8-bit",
+    "tree_sha256": "00244f54c1c1065086ac55a39cf842e0319446a816b46509dd69bc15a7c4bd3a"
+  },
+  "runtime": {
+    "engine": "mlx-lm",
+    "mlx_version": "0.32.2",
+    "mlx_lm_version": "0.31.3",
+    "context_length": 262144,
+    "route": "http://127.0.0.1:8091/v1 model auto"
+  },
+  "screening": {
+    "status": "pass",
+    "quality_pass_rate": 1.0,
+    "context_pass_rate": 1.0,
+    "effective_output_tokens_per_second": 15.494402,
+    "measured_prompt_tokens": 1268,
+    "measured_completion_tokens": 78,
+    "peak_unified_memory_used_mib": 52415,
+    "peak_process_rss_mib": 27660,
+    "raw_evidence_sha256": "sha256:3f8dddbac063a01d747c59721e34869d0eaad0e0fd39e24c5a4f09f7e900034a"
+  },
+  "extended": {
+    "status": "pass",
+    "passkey_context_words": [8192, 32768, 65536],
+    "quality_pass_rate": 1.0,
+    "context_pass_rate": 1.0,
+    "effective_output_tokens_per_second": 17.968452,
+    "measured_prompt_tokens": 122055,
+    "measured_completion_tokens": 540,
+    "peak_unified_memory_used_mib": 63631,
+    "peak_process_rss_mib": 27673,
+    "raw_evidence_sha256": "sha256:7924d112fb9ea7d8d9b2cb6772bf94a82a8f050a11df9113d724aea18e914fda"
+  },
+  "matched_long_code": {
+    "prompt_id": "long_warm_code_continuation",
+    "prompt_sha256": "sha256:babfc7f67bd8ec7a23439467a494b5bbe54538251e67ed7d2f8678d3c15fbe91",
+    "sampler": {
+      "temperature": 1.0,
+      "top_p": 0.95,
+      "top_k": 20,
+      "seed": 0
+    },
+    "completion_tokens": 512,
+    "finish_reason": "length",
+    "elapsed_seconds": 29.583446,
+    "end_to_end_tokens_per_second": 17.306976,
+    "raw_evidence_sha256": "sha256:13890ab1da62ffa596af0cb288aa2adc80e0291ce86184a4b045fcac375e98fb"
+  },
+  "limitations": [
+    "The generic mlx-lm response did not expose a server-side TTFT metric; no TTFT value is inferred.",
+    "These measurements apply only to the exact artifact, runtime, route, and hardware above.",
+    "The matched MTPLX comparison uses different model artifacts and is an end-product comparison, not an engine-only attribution."
+  ]
+}

--- a/schemas.py
+++ b/schemas.py
@@ -80,7 +80,7 @@ TURBOFIT_CONFIGURE = {
             },
             "install_native": {
                 "type": "boolean",
-                "description": "Install or verify the pinned native adaptive runtime.",
+                "description": "Explicitly install and activate the pinned native runtime. On supported Apple Silicon this downloads the selected MLX snapshot and starts loopback model and gateway processes.",
             },
             "install_freetoken": {
                 "type": "boolean",

--- a/scripts/install-mlx-runtime
+++ b/scripts/install-mlx-runtime
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Install or verify Turbofit's isolated pinned MLX/MLX-LM runtime."""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import platform
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Callable
+
+
+def _ensure_modern_python() -> None:
+    if sys.version_info >= (3, 10):
+        return
+    uv = shutil.which("uv")
+    if not uv:
+        raise RuntimeError("Python 3.10+ or uv is required to install the MLX runtime")
+    os.execv(uv, [uv, "run", "--python", "3.12", "python", __file__, *sys.argv[1:]])
+
+
+_ensure_modern_python()
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from turbofit_runtime.apple_mlx import MLX_LM_VERSION, MLX_VERSION  # noqa: E402
+
+
+def probe_versions(python: Path) -> dict[str, str]:
+    code = (
+        "import importlib.metadata as m, json; "
+        "print(json.dumps({'mlx': m.version('mlx'), 'mlx-lm': m.version('mlx-lm')}))"
+    )
+    output = subprocess.check_output([str(python), "-c", code], text=True, timeout=30)
+    return json.loads(output)
+
+
+def install(
+    *,
+    runtime_root: Path,
+    uv: str,
+    platform_name: str = sys.platform,
+    architecture: str = platform.machine(),
+    run: Callable[..., object] | None = None,
+    version_probe: Callable[[Path], dict[str, str]] = probe_versions,
+) -> dict[str, object]:
+    if platform_name != "darwin" or architecture.lower() not in {"arm64", "aarch64"}:
+        raise RuntimeError("MLX runtime requires Apple Silicon macOS")
+    execute = run or (lambda command, **kwargs: subprocess.run(command, check=True, **kwargs))
+    target = runtime_root.expanduser().resolve() / f"mlx-lm-{MLX_LM_VERSION}"
+    venv = target / ".venv"
+    python = venv / "bin" / "python"
+    if not python.is_file():
+        target.mkdir(parents=True, exist_ok=True)
+        execute([uv, "venv", "--python", "3.12", str(venv)])
+        execute([
+            uv,
+            "pip",
+            "install",
+            "--python",
+            str(python),
+            f"mlx=={MLX_VERSION}",
+            f"mlx-lm=={MLX_LM_VERSION}",
+        ])
+    versions = version_probe(python)
+    expected = {"mlx": MLX_VERSION, "mlx-lm": MLX_LM_VERSION}
+    if versions != expected:
+        raise RuntimeError(f"MLX runtime version mismatch: {versions} != {expected}")
+    return {
+        "schema": "turbofit.python-runtime-verification/v1",
+        "id": "mlx-lm",
+        "status": "verified",
+        "python": str(python),
+        "versions": versions,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--runtime-root",
+        type=Path,
+        default=Path("~/.local/share/turbofit/runtimes").expanduser(),
+    )
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+    uv = shutil.which("uv")
+    if not uv:
+        parser.error("uv is required to install the pinned MLX runtime")
+    result = install(runtime_root=args.runtime_root, uv=uv)
+    print(json.dumps(result, indent=2) if args.json else result["python"])
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/turbofit-gateway-runtime
+++ b/scripts/turbofit-gateway-runtime
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Manage Turbofit's owned loopback provider gateway."""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def _ensure_modern_python() -> None:
+    if sys.version_info >= (3, 10):
+        return
+    configured = os.environ.get("TURBOFIT_PYTHON")
+    candidates = ([Path(configured).expanduser()] if configured else []) + sorted(
+        Path("~/.local/share/turbofit/runtimes").expanduser().glob(
+            "mlx-lm-*/.venv/bin/python"
+        ),
+        reverse=True,
+    )
+    for candidate in candidates:
+        if candidate.is_file() and os.access(candidate, os.X_OK):
+            os.execv(str(candidate), [str(candidate), __file__, *sys.argv[1:]])
+    raise RuntimeError("Turbofit requires Python 3.10+; install the managed MLX runtime first")
+
+
+_ensure_modern_python()
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from turbofit_runtime.gateway_runtime import build_gateway_launch  # noqa: E402
+from turbofit_runtime.managed_engine import ManagedEngineRuntime  # noqa: E402
+
+
+def run_action(
+    action: str,
+    *,
+    runtime: ManagedEngineRuntime,
+    python: Path,
+    plugin_root: Path,
+    routes_path: Path,
+    port: int,
+    timeout_s: float,
+) -> dict[str, Any]:
+    if action == "start":
+        launch = build_gateway_launch(
+            python=python,
+            plugin_root=plugin_root,
+            routes_path=routes_path,
+            port=port,
+        )
+        resident = runtime.start_owned(launch, timeout_s=timeout_s)
+        return {
+            "ok": True,
+            "action": "start",
+            "pid": resident.pid,
+            "owned": resident.owned,
+        }
+    if action == "stop":
+        return {"ok": runtime.stop(), "action": "stop"}
+    if action == "status":
+        return {"action": "status", **runtime.inspect()}
+    raise ValueError(f"unsupported action: {action}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("action", choices=("start", "status", "stop"))
+    parser.add_argument("--python", type=Path, default=Path(sys.executable))
+    parser.add_argument("--plugin-root", type=Path, default=ROOT)
+    parser.add_argument(
+        "--routes",
+        type=Path,
+        default=Path(
+            os.getenv(
+                "TURBOFIT_RUNTIME_STATE",
+                "~/.local/state/turbofit/runtime-state.json",
+            )
+        ).expanduser(),
+    )
+    parser.add_argument(
+        "--state",
+        type=Path,
+        default=Path("~/.local/state/turbofit/gateway.json").expanduser(),
+    )
+    parser.add_argument("--port", type=int, default=8091)
+    parser.add_argument("--timeout", type=float, default=90.0)
+    args = parser.parse_args()
+    result = run_action(
+        args.action,
+        runtime=ManagedEngineRuntime(state_path=args.state),
+        python=args.python,
+        plugin_root=args.plugin_root,
+        routes_path=args.routes,
+        port=args.port,
+        timeout_s=args.timeout,
+    )
+    print(json.dumps(result, indent=2))
+    return 0 if result.get("ok") else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/turbofit-gateway.py
+++ b/scripts/turbofit-gateway.py
@@ -361,6 +361,22 @@ def check_port(port):
         return False
 
 
+def served_model_ids(port):
+    """Exact model IDs advertised by a local OpenAI-compatible backend."""
+    try:
+        with urlopen(f"http://127.0.0.1:{port}/v1/models", timeout=3) as response:
+            payload = json.load(response)
+    except Exception:
+        return set()
+    if not isinstance(payload, dict) or not isinstance(payload.get("data"), list):
+        return set()
+    return {
+        str(item.get("id"))
+        for item in payload["data"]
+        if isinstance(item, dict) and item.get("id")
+    }
+
+
 def runtime_override(role):
     """Resolve an explicitly activated evidence-backed runtime before catalog roles.
 
@@ -454,7 +470,8 @@ def _runtime_policy_route(state, role):
             port = int(route.get("port") or 0)
         except (TypeError, ValueError):
             return None
-        state_name = backend_state(port, alias)
+        model_id = str(route.get("model_id") or alias).strip()
+        state_name = backend_state(port, model_id)
         if state_name == "down":
             return None
         result = {
@@ -465,6 +482,9 @@ def _runtime_policy_route(state, role):
             "runtime_profile": state.get("active"),
             "runtime_rung": state.get("rung_id"),
         }
+        model_id = str(route.get("model_id") or "").strip()
+        if model_id:
+            result["model_id"] = model_id
         if route.get("context_length"):
             result["context_length"] = route["context_length"]
         if isinstance(route.get("request_policy"), dict):
@@ -496,7 +516,7 @@ def _runtime_policy_route(state, role):
     return None
 
 
-def backend_state(port, alias=None):
+def backend_state(port, expected_model_id=None):
     """Returns one of: 'ready', 'loading', 'down'.
 
     The port-SELF_PORT guard prevents a model registered on the gateway's own
@@ -508,6 +528,8 @@ def backend_state(port, alias=None):
     if not port_is_open(port):
         return "down"
     if check_port(port):
+        if expected_model_id and expected_model_id not in served_model_ids(port):
+            return "down"
         return "ready"
     return "loading"
 
@@ -771,14 +793,14 @@ def resolve_aux():
 
 # ─── Stall-while-loading ─────────────────────────────────────────────────────
 
-def stall_until_ready(port, deadline_ts, alias=None):
-    """Block (with periodic progress logs) until the local model is ready
+def stall_until_ready(port, deadline_ts, expected_model_id=None):
+    """Block (with periodic progress logs) until the exact local model is ready
     OR the deadline elapses. Returns the final state."""
     waited = 0.0
     poll = STALL_POLL_S
     last_log = 0.0
     while time.time() < deadline_ts:
-        state = backend_state(port, alias)
+        state = backend_state(port, expected_model_id)
         if state == "ready":
             if waited > 1.0:
                 log.info(f"Local backend :{port} ready after {waited:.1f}s stall")
@@ -794,7 +816,7 @@ def stall_until_ready(port, deadline_ts, alias=None):
         waited += poll
         # Gentle backoff capped at 5s
         poll = min(poll * 1.1, 5.0)
-    return backend_state(port, alias)  # final state at deadline
+    return backend_state(port, expected_model_id)  # final state at deadline
 
 
 # ─── HTTP handler ─────────────────────────────────────────────────────────────
@@ -906,7 +928,11 @@ class GatewayHandler(BaseHTTPRequestHandler):
             port = backend.get("port", 0)
             log.info(f"Stall-while-loading: :{port} (timeout {STALL_TIMEOUT_S:.0f}s)")
             stalled = True
-            new_state = stall_until_ready(port, deadline, backend.get("alias"))
+            new_state = stall_until_ready(
+                port,
+                deadline,
+                backend.get("model_id") or backend.get("alias"),
+            )
             if new_state == "ready":
                 backend["state"] = "ready"
             else:
@@ -1024,8 +1050,7 @@ class GatewayHandler(BaseHTTPRequestHandler):
                     payload["chat_template_kwargs"] = template_kwargs
                     payload.setdefault("reasoning_format", "none")
                 payload["model"] = (
-                    backend.get("model_id") if backend.get("is_api")
-                    else backend.get("alias")
+                    backend.get("model_id") or backend.get("alias")
                 ) or payload.get("model")
                 body = json.dumps(payload).encode()
             except Exception:

--- a/scripts/turbofit-mlx-runtime
+++ b/scripts/turbofit-mlx-runtime
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Manage Turbofit's owned generic Apple MLX runtime."""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def _ensure_modern_python() -> None:
+    if sys.version_info >= (3, 10):
+        return
+    configured = os.environ.get("TURBOFIT_PYTHON")
+    candidates = ([Path(configured).expanduser()] if configured else []) + sorted(
+        Path("~/.local/share/turbofit/runtimes").expanduser().glob(
+            "mlx-lm-*/.venv/bin/python"
+        ),
+        reverse=True,
+    )
+    for candidate in candidates:
+        if candidate.is_file() and os.access(candidate, os.X_OK):
+            os.execv(str(candidate), [str(candidate), __file__, *sys.argv[1:]])
+    raise RuntimeError("Turbofit requires Python 3.10+; install the managed MLX runtime first")
+
+
+_ensure_modern_python()
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from turbofit_runtime.apple_mlx import build_apple_mlx_launch  # noqa: E402
+from turbofit_runtime.managed_engine import (  # noqa: E402
+    ManagedEngineRuntime,
+    publish_engine_routes,
+)
+
+
+def _remove_own_routes(path: Path) -> None:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError, json.JSONDecodeError):
+        return
+    if payload.get("active") == "apple-mlx":
+        path.unlink(missing_ok=True)
+
+
+def run_action(
+    action: str,
+    *,
+    runtime: ManagedEngineRuntime,
+    model_root: Path,
+    runtime_root: Path,
+    routes_path: Path,
+    port: int,
+    timeout_s: float,
+) -> dict[str, Any]:
+    launch = build_apple_mlx_launch(
+        model_root=model_root,
+        runtime_root=runtime_root,
+        port=port,
+    )
+    if action == "start":
+        resident = runtime.start_owned(launch, timeout_s=timeout_s)
+        publish_engine_routes(routes_path, launch)
+        return {
+            "ok": True,
+            "action": "start",
+            "pid": resident.pid,
+            "owned": resident.owned,
+        }
+    if action == "stop":
+        stopped = runtime.stop()
+        if stopped:
+            _remove_own_routes(routes_path)
+        return {"ok": stopped, "action": "stop"}
+    if action == "status":
+        return {"action": "status", **runtime.inspect()}
+    raise ValueError(f"unsupported action: {action}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("action", choices=("start", "status", "stop"))
+    parser.add_argument(
+        "--model-root",
+        type=Path,
+        default=Path(os.getenv("TURBOFIT_MODEL_ROOT", "~/Models/storage/gguf")).expanduser(),
+    )
+    parser.add_argument(
+        "--runtime-root",
+        type=Path,
+        default=Path("~/.local/share/turbofit/runtimes").expanduser(),
+    )
+    parser.add_argument(
+        "--state",
+        type=Path,
+        default=Path("~/.local/state/turbofit/engines/mlx.json").expanduser(),
+    )
+    parser.add_argument(
+        "--routes",
+        type=Path,
+        default=Path(
+            os.getenv(
+                "TURBOFIT_RUNTIME_STATE",
+                "~/.local/state/turbofit/runtime-state.json",
+            )
+        ).expanduser(),
+    )
+    parser.add_argument("--port", type=int, default=18081)
+    parser.add_argument("--timeout", type=float, default=900.0)
+    args = parser.parse_args()
+    runtime = ManagedEngineRuntime(state_path=args.state)
+    result = run_action(
+        args.action,
+        runtime=runtime,
+        model_root=args.model_root,
+        runtime_root=args.runtime_root,
+        routes_path=args.routes,
+        port=args.port,
+        timeout_s=args.timeout,
+    )
+    print(json.dumps(result, indent=2))
+    return 0 if result.get("ok") else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/turbofit_runtime/apple_mlx.py
+++ b/src/turbofit_runtime/apple_mlx.py
@@ -1,0 +1,77 @@
+"""Pinned generic MLX lane for Apple Silicon."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from .managed_engine import EngineLaunch
+
+
+MLX_VERSION = "0.32.2"
+MLX_LM_VERSION = "0.31.3"
+MODEL_REPO = "orcarouter/Qwen3.8-27B-Uncensored-MLX"
+MODEL_REVISION = "b4603df5fd2a51e7fed2560ee7090caa4e13e4b7"
+MODEL_FAMILY = "qwen3-8-27b-uncensored-mlx-8bit"
+MODEL_RELATIVE_PATH = Path("Qwen3.8-27B-Uncensored-MLX/8-bit")
+MODEL_CONTEXT = 262_144
+DEFAULT_RESPONSE_TOKENS = 32_768
+
+
+def load_python_runtime(path: str | Path, runtime_id: str) -> dict[str, Any]:
+    payload = json.loads(Path(path).read_text(encoding="utf-8"))
+    if payload.get("schema") != "turbofit.python-runtimes/v1":
+        raise ValueError("unsupported Python runtime manifest")
+    runtimes = payload.get("runtimes")
+    if not isinstance(runtimes, dict) or runtime_id not in runtimes:
+        raise KeyError(f"unknown Python runtime: {runtime_id}")
+    runtime = runtimes[runtime_id]
+    if not isinstance(runtime, dict):
+        raise ValueError(f"invalid Python runtime: {runtime_id}")
+    return runtime
+
+
+def build_apple_mlx_launch(
+    *,
+    model_root: str | Path,
+    runtime_root: str | Path,
+    port: int = 18081,
+) -> EngineLaunch:
+    model_path = Path(model_root).expanduser().resolve() / MODEL_RELATIVE_PATH
+    python = (
+        Path(runtime_root).expanduser().resolve()
+        / f"mlx-lm-{MLX_LM_VERSION}"
+        / ".venv"
+        / "bin"
+        / "python"
+    )
+    command = (
+        str(python),
+        "-m",
+        "mlx_lm",
+        "server",
+        "--model",
+        str(model_path),
+        "--host",
+        "127.0.0.1",
+        "--port",
+        str(port),
+        "--temp",
+        "1.0",
+        "--top-p",
+        "0.95",
+        "--top-k",
+        "20",
+        "--max-tokens",
+        str(DEFAULT_RESPONSE_TOKENS),
+    )
+    return EngineLaunch(
+        engine_id="mlx",
+        model_id=MODEL_FAMILY,
+        model_path=model_path,
+        port=port,
+        context_length=MODEL_CONTEXT,
+        bind_host="127.0.0.1",
+        upstream_model_id=str(model_path),
+        command=command,
+    )

--- a/src/turbofit_runtime/gateway_runtime.py
+++ b/src/turbofit_runtime/gateway_runtime.py
@@ -1,0 +1,37 @@
+"""Owned loopback launch contract for the Turbofit provider gateway."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from .managed_engine import EngineLaunch
+
+
+def build_gateway_launch(
+    *,
+    python: str | Path,
+    plugin_root: str | Path,
+    routes_path: str | Path,
+    port: int = 8091,
+) -> EngineLaunch:
+    root = Path(plugin_root).resolve()
+    script = root / "scripts" / "turbofit-gateway.py"
+    routes = Path(routes_path).expanduser().resolve()
+    command = (
+        "/usr/bin/env",
+        "TURBOFIT_GATEWAY_HOST=127.0.0.1",
+        f"TURBOFIT_GATEWAY_PORT={port}",
+        f"TURBOFIT_RUNTIME_STATE={routes}",
+        str(Path(python).expanduser().resolve()),
+        str(script),
+    )
+    return EngineLaunch(
+        engine_id="turbofit-gateway",
+        model_id="auto",
+        model_path=root,
+        port=port,
+        context_length=262_144,
+        bind_host="127.0.0.1",
+        upstream_model_id="auto",
+        command=command,
+        required_model_files=(),
+    )

--- a/src/turbofit_runtime/managed_engine.py
+++ b/src/turbofit_runtime/managed_engine.py
@@ -1,0 +1,402 @@
+"""Ownership-safe lifecycle for loopback OpenAI-compatible model engines."""
+from __future__ import annotations
+
+import ipaddress
+import json
+import os
+import shlex
+import signal
+import subprocess
+import time
+import urllib.request
+from contextlib import contextmanager
+from dataclasses import asdict, dataclass, replace
+from pathlib import Path
+from typing import Any, Callable, Mapping
+
+from .routes import publish_route_state
+
+
+@dataclass(frozen=True)
+class EngineLaunch:
+    engine_id: str
+    model_id: str
+    model_path: Path
+    port: int
+    context_length: int
+    bind_host: str
+    upstream_model_id: str
+    command: tuple[str, ...]
+    required_model_files: tuple[str, ...] = ("config.json",)
+
+    def __post_init__(self) -> None:
+        if not self.engine_id or not self.model_id or not self.upstream_model_id or not self.command:
+            raise ValueError("engine, model, and command must be non-empty")
+        if isinstance(self.port, bool) or not 1 <= self.port <= 65535:
+            raise ValueError("engine port must be in 1..65535")
+        if isinstance(self.context_length, bool) or self.context_length <= 0:
+            raise ValueError("context_length must be positive")
+        try:
+            address = ipaddress.ip_address(self.bind_host)
+        except ValueError as exc:
+            raise ValueError("managed engine bind host must be an IP address") from exc
+        if not address.is_loopback:
+            raise ValueError("managed engines must bind to loopback")
+
+
+@dataclass(frozen=True)
+class EngineResident:
+    engine_id: str
+    model_id: str
+    model_path: str
+    port: int
+    context_length: int
+    bind_host: str
+    upstream_model_id: str
+    pid: int
+    command: tuple[str, ...]
+    owned: bool
+    status: str = "ready"
+
+
+class ManagedEngineRuntime:
+    """Start or adopt an engine while signalling only a verified owned PID."""
+
+    def __init__(
+        self,
+        *,
+        state_path: str | Path,
+        process_factory: Callable[..., Any] = subprocess.Popen,
+        command_line: Callable[[int], str] | None = None,
+        listener_pids: Callable[[int], tuple[int, ...]] | None = None,
+        signal_process: Callable[[int, int], None] = os.kill,
+        json_get: Callable[[str, float], Any] | None = None,
+        sleep: Callable[[float], None] = time.sleep,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self.state_path = Path(state_path)
+        self.lock_path = self.state_path.with_suffix(".lock")
+        self.process_factory = process_factory
+        self.command_line = command_line or self._command_line
+        self.listener_pids = listener_pids or self._listener_pids
+        self.signal_process = signal_process
+        self.json_get = json_get or self._json_get
+        self.sleep = sleep
+        self.clock = clock
+        self._resident: EngineResident | None = None
+        self._process: Any | None = None
+
+    @contextmanager
+    def _lifecycle_lock(self):
+        self.lock_path.parent.mkdir(parents=True, exist_ok=True)
+        with self.lock_path.open("a+") as handle:
+            if os.name == "nt":
+                import msvcrt
+
+                handle.seek(0)
+                msvcrt.locking(handle.fileno(), msvcrt.LK_LOCK, 1)
+                try:
+                    yield
+                finally:
+                    handle.seek(0)
+                    msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+            else:
+                import fcntl
+
+                fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+                try:
+                    yield
+                finally:
+                    fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
+    @staticmethod
+    def _command_line(pid: int) -> str:
+        try:
+            result = subprocess.run(
+                ["ps", "-p", str(pid), "-o", "command="],
+                capture_output=True,
+                text=True,
+                timeout=3,
+                check=False,
+            )
+        except (OSError, subprocess.SubprocessError):
+            return ""
+        return result.stdout.strip() if result.returncode == 0 else ""
+
+    @staticmethod
+    def _listener_pids(port: int) -> tuple[int, ...]:
+        try:
+            result = subprocess.run(
+                ["lsof", "-nP", f"-iTCP:{port}", "-sTCP:LISTEN", "-t"],
+                capture_output=True,
+                text=True,
+                timeout=3,
+                check=False,
+            )
+        except (OSError, subprocess.SubprocessError):
+            return ()
+        if result.returncode not in {0, 1}:
+            return ()
+        return tuple(
+            int(line)
+            for line in result.stdout.splitlines()
+            if line.strip().isdigit()
+        )
+
+    @staticmethod
+    def _json_get(url: str, timeout: float) -> Any:
+        with urllib.request.urlopen(url, timeout=timeout) as response:
+            return json.loads(response.read().decode("utf-8"))
+
+    @staticmethod
+    def _resident_for(spec: EngineLaunch, *, pid: int, owned: bool) -> EngineResident:
+        return EngineResident(
+            engine_id=spec.engine_id,
+            model_id=spec.model_id,
+            model_path=str(spec.model_path),
+            port=spec.port,
+            context_length=spec.context_length,
+            bind_host=spec.bind_host,
+            upstream_model_id=spec.upstream_model_id,
+            pid=pid,
+            command=spec.command,
+            owned=owned,
+        )
+
+    def _ready(self, spec: EngineLaunch) -> bool:
+        base = f"http://127.0.0.1:{spec.port}"
+        try:
+            models = self.json_get(base + "/v1/models", 2.0)
+        except (OSError, ValueError):
+            return False
+        if not isinstance(models, Mapping):
+            return False
+        ids = {
+            str(item.get("id"))
+            for item in (models.get("data") or [])
+            if isinstance(item, dict)
+        }
+        if spec.upstream_model_id not in ids:
+            return False
+        try:
+            health = self.json_get(base + "/health", 2.0)
+        except (OSError, ValueError):
+            return True
+        if not isinstance(health, dict):
+            return False
+        return bool(
+            health.get("ok") is True
+            or health.get("status") in {"ok", "ready", "healthy", "loaded"}
+        )
+
+    def _write_owned(self, resident: EngineResident) -> None:
+        payload = {
+            "schema": "turbofit.managed-engine/v1",
+            **asdict(resident),
+            "command": list(resident.command),
+        }
+        publish_route_state(self.state_path, payload)
+
+    def start_owned(self, spec: EngineLaunch, *, timeout_s: float = 900.0) -> EngineResident:
+        with self._lifecycle_lock():
+            return self._start_owned(spec, timeout_s=timeout_s)
+
+    def _start_owned(self, spec: EngineLaunch, *, timeout_s: float) -> EngineResident:
+        executable = Path(spec.command[0])
+        if not executable.is_file() or not os.access(executable, os.X_OK):
+            raise RuntimeError(f"engine executable is unavailable: {executable}")
+        if not spec.model_path.is_dir() or any(
+            not (spec.model_path / relative).is_file()
+            for relative in spec.required_model_files
+        ):
+            raise RuntimeError(f"model snapshot is incomplete: {spec.model_path}")
+        occupants = self.listener_pids(spec.port)
+        if occupants:
+            raise RuntimeError(
+                f"engine port {spec.port} is already occupied by PID(s) "
+                + ",".join(str(pid) for pid in occupants)
+            )
+        log_path = self.state_path.with_suffix(".log")
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        log = log_path.open("a", encoding="utf-8")
+        process = self.process_factory(
+            list(spec.command),
+            stdout=log,
+            stderr=subprocess.STDOUT,
+            text=True,
+            start_new_session=True,
+        )
+        log.close()
+        self._process = process
+        resident = replace(
+            self._resident_for(spec, pid=int(process.pid), owned=True),
+            status="launching",
+        )
+        self._write_owned(resident)
+        deadline = self.clock() + timeout_s
+        while True:
+            if process.poll() is not None:
+                break
+            if self._ready(spec) and resident.pid in self.listener_pids(spec.port):
+                actual = self.command_line(resident.pid)
+                if actual:
+                    try:
+                        resident = replace(resident, command=tuple(shlex.split(actual)))
+                    except ValueError:
+                        pass
+                resident = replace(resident, status="ready")
+                self._resident = resident
+                self._write_owned(resident)
+                return resident
+            if self.clock() >= deadline:
+                break
+            self.sleep(min(0.5, max(0.0, deadline - self.clock())))
+        if process.poll() is None:
+            process.terminate()
+        cleanup_deadline = time.monotonic() + 30.0
+        while process.poll() is None and time.monotonic() < cleanup_deadline:
+            self.sleep(0.2)
+        if process.poll() is None:
+            resident = replace(resident, status="cleanup-timeout")
+            self._resident = resident
+            self._write_owned(resident)
+        else:
+            self._resident = None
+            self.state_path.unlink(missing_ok=True)
+        self._process = None
+        raise RuntimeError(f"{spec.engine_id} did not become ready with model {spec.model_id}")
+
+    def adopt_external(self, spec: EngineLaunch, *, pid: int) -> EngineResident:
+        if pid <= 0 or not self._ready(spec):
+            raise RuntimeError(f"external {spec.engine_id} endpoint is not ready")
+        if pid not in self.listener_pids(spec.port):
+            raise RuntimeError(
+                f"external {spec.engine_id} PID {pid} does not own port {spec.port}"
+            )
+        resident = self._resident_for(spec, pid=pid, owned=False)
+        self._resident = resident
+        return resident
+
+    @staticmethod
+    def _command_matches(expected: tuple[str, ...], actual: str) -> bool:
+        if not actual:
+            return False
+        try:
+            observed = shlex.split(actual)
+        except ValueError:
+            return False
+        return tuple(observed) == expected
+
+    def _load_record(self) -> EngineResident | None:
+        if self._resident is not None:
+            return self._resident
+        try:
+            raw = json.loads(self.state_path.read_text(encoding="utf-8"))
+            if raw.get("schema") != "turbofit.managed-engine/v1":
+                return None
+            return EngineResident(
+                engine_id=str(raw["engine_id"]),
+                model_id=str(raw["model_id"]),
+                model_path=str(raw["model_path"]),
+                port=int(raw["port"]),
+                context_length=int(raw["context_length"]),
+                bind_host=str(raw["bind_host"]),
+                upstream_model_id=str(raw["upstream_model_id"]),
+                pid=int(raw["pid"]),
+                command=tuple(str(item) for item in raw["command"]),
+                owned=raw["owned"] is True,
+                status=str(raw.get("status") or "ready"),
+            )
+        except (OSError, ValueError, TypeError, KeyError, json.JSONDecodeError):
+            return None
+
+    def inspect(self) -> dict[str, Any]:
+        resident = self._load_record()
+        if resident is None:
+            return {"ok": False, "status": "down", "runtime": None}
+        payload = {
+            "engine_id": resident.engine_id,
+            "model_id": resident.model_id,
+            "pid": resident.pid,
+            "port": resident.port,
+            "owned": resident.owned,
+        }
+        if resident.owned and not self._command_matches(
+            resident.command, self.command_line(resident.pid)
+        ):
+            return {"ok": False, "status": "stale", "runtime": payload}
+        if resident.pid not in self.listener_pids(resident.port):
+            return {"ok": False, "status": "stale", "runtime": payload}
+        spec = EngineLaunch(
+            engine_id=resident.engine_id,
+            model_id=resident.model_id,
+            model_path=Path(resident.model_path),
+            port=resident.port,
+            context_length=resident.context_length,
+            bind_host=resident.bind_host,
+            upstream_model_id=resident.upstream_model_id,
+            command=resident.command,
+            required_model_files=(),
+        )
+        if not self._ready(spec):
+            return {"ok": False, "status": "loading", "runtime": payload}
+        return {"ok": True, "status": "ready", "runtime": payload}
+
+    def stop(self, *, timeout_s: float = 30.0) -> bool:
+        with self._lifecycle_lock():
+            return self._stop(timeout_s=timeout_s)
+
+    def _stop(self, *, timeout_s: float) -> bool:
+        resident = self._load_record()
+        if resident is None or not resident.owned:
+            self._resident = None
+            self.state_path.unlink(missing_ok=True)
+            return True
+        actual = self.command_line(resident.pid)
+        if not self._command_matches(resident.command, actual):
+            resident = replace(resident, status="command-mismatch")
+            self._resident = resident
+            self._write_owned(resident)
+            return False
+        if self._process is not None:
+            self._process.terminate()
+        else:
+            self.signal_process(resident.pid, signal.SIGTERM)
+        deadline = self.clock() + max(0.0, timeout_s)
+        while self.clock() < deadline:
+            actual = self.command_line(resident.pid)
+            if not self._command_matches(resident.command, actual):
+                self._resident = None
+                self._process = None
+                self.state_path.unlink(missing_ok=True)
+                return True
+            self.sleep(0.2)
+        resident = replace(resident, status="stop-timeout")
+        self._resident = resident
+        self._write_owned(resident)
+        return False
+
+
+def publish_engine_routes(path: str | Path, spec: EngineLaunch) -> None:
+    publish_route_state(
+        path,
+        {
+            "schema": "turbofit.runtime-routes/v1",
+            "active": f"apple-{spec.engine_id}",
+            "rung_id": f"{spec.engine_id}-{spec.model_id}",
+            "routes": {
+                "main": {
+                    "kind": "local",
+                    "alias": spec.model_id,
+                    "model_id": spec.upstream_model_id,
+                    "port": spec.port,
+                    "context_length": spec.context_length,
+                    "engine": spec.engine_id,
+                },
+                "aux": {
+                    "kind": "shared-main",
+                    "context_length": spec.context_length,
+                },
+            },
+        },
+    )

--- a/tests/test_apple_mlx_runtime.py
+++ b/tests/test_apple_mlx_runtime.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from turbofit_runtime.apple_mlx import (
+    MLX_LM_VERSION,
+    MLX_VERSION,
+    MODEL_FAMILY,
+    MODEL_REVISION,
+    MODEL_REPO,
+    build_apple_mlx_launch,
+    load_python_runtime,
+)
+
+
+ROOT = Path(__file__).parents[1]
+
+
+def test_apple_mlx_runtime_and_model_are_immutably_pinned(tmp_path: Path) -> None:
+    runtime = load_python_runtime(ROOT / "references/python-runtimes.json", "mlx-lm")
+
+    assert runtime["packages"] == {
+        "mlx": f"mlx=={MLX_VERSION}",
+        "mlx-lm": f"mlx-lm=={MLX_LM_VERSION}",
+    }
+    assert MODEL_REPO == "orcarouter/Qwen3.8-27B-Uncensored-MLX"
+    assert MODEL_REVISION == "b4603df5fd2a51e7fed2560ee7090caa4e13e4b7"
+    assert MODEL_FAMILY == "qwen3-8-27b-uncensored-mlx-8bit"
+
+
+def test_build_apple_mlx_launch_uses_loopback_and_real_upstream_model_id(
+    tmp_path: Path,
+) -> None:
+    runtime_root = tmp_path / "runtimes"
+    python = runtime_root / f"mlx-lm-{MLX_LM_VERSION}" / ".venv/bin/python"
+    python.parent.mkdir(parents=True)
+    python.write_text("python")
+    python.chmod(0o755)
+    model_root = tmp_path / "models"
+    model = model_root / "Qwen3.8-27B-Uncensored-MLX/8-bit"
+    model.mkdir(parents=True)
+    (model / "config.json").write_text("{}")
+
+    launch = build_apple_mlx_launch(
+        model_root=model_root,
+        runtime_root=runtime_root,
+        port=18081,
+    )
+
+    assert launch.engine_id == "mlx"
+    assert launch.model_id == MODEL_FAMILY
+    assert launch.upstream_model_id == str(model)
+    assert launch.context_length == 262_144
+    assert launch.command == (
+        str(python),
+        "-m",
+        "mlx_lm",
+        "server",
+        "--model",
+        str(model),
+        "--host",
+        "127.0.0.1",
+        "--port",
+        "18081",
+        "--temp",
+        "1.0",
+        "--top-p",
+        "0.95",
+        "--top-k",
+        "20",
+        "--max-tokens",
+        "32768",
+    )

--- a/tests/test_artifact_manifest.py
+++ b/tests/test_artifact_manifest.py
@@ -26,11 +26,29 @@ def test_artifact_manifest_covers_every_executable_matrix_file() -> None:
     model_root = Path.home() / "Models/storage/gguf"
     expected_destinations = {str(Path(path).relative_to(model_root)) for path in expected}
     actual = {item["destination"] for item in payload["artifacts"]}
+    mlx_destinations = {
+        item["destination"]
+        for item in payload["artifacts"]
+        if "qwen3-8-27b-uncensored-mlx-8bit" in item.get("families", [])
+    }
+    known_non_matrix_destinations = {
+        item["destination"]
+        for item in payload["artifacts"]
+        if item.get("repo_id") == "unsloth/MiniMax-M3-GGUF"
+    }
 
     assert payload["schema"] == "turbofit.artifact-manifest/v1"
     assert expected_destinations <= actual
-    assert len(actual) == 36
-    assert all(len(item["sha256"]) == 64 for item in payload["artifacts"])
+    assert actual == expected_destinations | known_non_matrix_destinations | mlx_destinations
+    assert mlx_destinations
+    assert all(
+        len(item["sha256"]) == 64
+        or (
+            item["sha256"].startswith("snapshot:")
+            and len(item["sha256"].removeprefix("snapshot:")) == 40
+        )
+        for item in payload["artifacts"]
+    )
     assert all(len(item["revision"]) == 40 for item in payload["artifacts"])
     assert all(item["size_bytes"] > 0 for item in payload["artifacts"])
 

--- a/tests/test_download_artifacts.py
+++ b/tests/test_download_artifacts.py
@@ -33,6 +33,42 @@ def test_selected_artifacts_filters_complete_family() -> None:
     }
 
 
+def test_apple_mlx_8bit_family_is_a_complete_pinned_snapshot() -> None:
+    module = load_script()
+    payload = __import__("json").loads((ROOT / "references/artifact-manifest.json").read_text())
+
+    selected = module.selected_artifacts(
+        payload, {"qwen3-8-27b-uncensored-mlx-8bit"}
+    )
+
+    assert {row["path"] for row in selected} == {
+        "8-bit/README.md",
+        "8-bit/chat_template.jinja",
+        "8-bit/config.json",
+        "8-bit/generation_config.json",
+        "8-bit/model-00001-of-00006.safetensors",
+        "8-bit/model-00002-of-00006.safetensors",
+        "8-bit/model-00003-of-00006.safetensors",
+        "8-bit/model-00004-of-00006.safetensors",
+        "8-bit/model-00005-of-00006.safetensors",
+        "8-bit/model-00006-of-00006.safetensors",
+        "8-bit/model.safetensors.index.json",
+        "8-bit/preprocessor_config.json",
+        "8-bit/processor_config.json",
+        "8-bit/tokenizer.json",
+        "8-bit/tokenizer_config.json",
+        "8-bit/video_preprocessor_config.json",
+        "8-bit/vocab.json",
+    }
+    assert {
+        row["revision"] for row in selected
+    } == {"b4603df5fd2a51e7fed2560ee7090caa4e13e4b7"}
+    assert all(
+        row["destination"].startswith("Qwen3.8-27B-Uncensored-MLX/8-bit/")
+        for row in selected
+    )
+
+
 def test_install_artifact_verifies_before_materializing(tmp_path: Path) -> None:
     module = load_script()
     cached = tmp_path / "cache" / "model.gguf"

--- a/tests/test_gateway_runtime.py
+++ b/tests/test_gateway_runtime.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from turbofit_runtime.gateway_runtime import build_gateway_launch
+
+
+def test_gateway_launch_is_loopback_only_and_uses_exact_route_state(tmp_path: Path) -> None:
+    plugin_root = tmp_path / "plugin"
+    script = plugin_root / "scripts/turbofit-gateway.py"
+    script.parent.mkdir(parents=True)
+    script.write_text("print('gateway')")
+    python = tmp_path / "python"
+    python.write_text("python")
+    python.chmod(0o755)
+    routes = tmp_path / "runtime-state.json"
+
+    launch = build_gateway_launch(
+        python=python,
+        plugin_root=plugin_root,
+        routes_path=routes,
+        port=8091,
+    )
+
+    assert launch.engine_id == "turbofit-gateway"
+    assert launch.model_id == "auto"
+    assert launch.upstream_model_id == "auto"
+    assert launch.required_model_files == ()
+    assert launch.command == (
+        "/usr/bin/env",
+        "TURBOFIT_GATEWAY_HOST=127.0.0.1",
+        "TURBOFIT_GATEWAY_PORT=8091",
+        f"TURBOFIT_RUNTIME_STATE={routes}",
+        str(python),
+        str(script),
+    )

--- a/tests/test_gateway_runtime_cli.py
+++ b/tests/test_gateway_runtime_cli.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+from types import SimpleNamespace
+
+
+ROOT = Path(__file__).parents[1]
+SCRIPT = ROOT / "scripts/turbofit-gateway-runtime"
+
+
+def load_script():
+    loader = SourceFileLoader("turbofit_gateway_runtime", str(SCRIPT))
+    spec = importlib.util.spec_from_loader(loader.name, loader)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class Runtime:
+    def __init__(self) -> None:
+        self.started = []
+        self.stopped = 0
+
+    def start_owned(self, launch, *, timeout_s):
+        self.started.append((launch, timeout_s))
+        return SimpleNamespace(pid=73, owned=True)
+
+    def stop(self):
+        self.stopped += 1
+        return True
+
+
+def test_gateway_cli_starts_owned_loopback_gateway(tmp_path: Path) -> None:
+    module = load_script()
+    runtime = Runtime()
+
+    result = module.run_action(
+        "start",
+        runtime=runtime,
+        python=tmp_path / "python",
+        plugin_root=ROOT,
+        routes_path=tmp_path / "routes.json",
+        port=8091,
+        timeout_s=30,
+    )
+
+    assert result == {"ok": True, "action": "start", "pid": 73, "owned": True}
+    assert runtime.started[0][0].engine_id == "turbofit-gateway"
+
+
+def test_gateway_cli_bootstraps_from_legacy_system_python(tmp_path: Path) -> None:
+    system_python = Path("/usr/bin/python3")
+    if not system_python.exists():
+        return
+    result = subprocess.run(
+        [str(system_python), str(SCRIPT), "status", "--state", str(tmp_path / "missing.json")],
+        text=True,
+        capture_output=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert "unsupported operand type" not in result.stderr
+    assert '"action": "status"' in result.stdout

--- a/tests/test_gateway_runtime_policy.py
+++ b/tests/test_gateway_runtime_policy.py
@@ -75,6 +75,14 @@ def test_health_probe_accepts_native_runtime_health(monkeypatch) -> None:
     assert GATEWAY.check_port(8092) is True
 
 
+def test_backend_state_rejects_a_healthy_listener_serving_the_wrong_model(monkeypatch) -> None:
+    monkeypatch.setattr(GATEWAY, "port_is_open", lambda _port: True)
+    monkeypatch.setattr(GATEWAY, "check_port", lambda _port: True)
+    monkeypatch.setattr(GATEWAY, "served_model_ids", lambda _port: {"another-model"}, raising=False)
+
+    assert GATEWAY.backend_state(18081, "expected-model") == "down"
+
+
 def test_explicit_api_fallback_precedes_interactive_profile_provider(tmp_path, monkeypatch) -> None:
     preferences = tmp_path / "preferences.yaml"
     preferences.write_text(
@@ -174,6 +182,28 @@ def test_dynamic_local_main_and_dedicated_aux_routes(tmp_path, monkeypatch) -> N
     assert main["base_url"] == "http://127.0.0.1:8080"
     assert aux["alias"] == "carwin"
     assert aux["mode"] == "dedicated"
+
+
+def test_local_engine_route_can_separate_stable_alias_from_upstream_model_id(
+    tmp_path, monkeypatch
+) -> None:
+    state = tmp_path / "runtime-state.json"
+    write_state(state, {
+        "main": {
+            "kind": "local",
+            "alias": "qwen3-8-27b-uncensored-mlx-8bit",
+            "model_id": "/models/Qwen3.8-27B-Uncensored-MLX/8-bit",
+            "port": 18081,
+        },
+        "aux": {"kind": "shared-main"},
+    })
+    monkeypatch.setattr(GATEWAY, "RUNTIME_STATE", str(state))
+    monkeypatch.setattr(GATEWAY, "backend_state", lambda _port, _alias=None: "ready")
+
+    main = GATEWAY.runtime_override("main")
+
+    assert main["alias"] == "qwen3-8-27b-uncensored-mlx-8bit"
+    assert main["model_id"] == "/models/Qwen3.8-27B-Uncensored-MLX/8-bit"
 
 
 def test_shared_main_aux_route_follows_current_main_without_restart(tmp_path, monkeypatch) -> None:

--- a/tests/test_managed_engine.py
+++ b/tests/test_managed_engine.py
@@ -1,0 +1,349 @@
+from __future__ import annotations
+
+import fcntl
+import json
+from pathlib import Path
+
+import pytest
+
+from turbofit_runtime.managed_engine import (
+    EngineLaunch,
+    ManagedEngineRuntime,
+    publish_engine_routes,
+)
+
+
+class FakeProcess:
+    def __init__(self, pid: int = 4321) -> None:
+        self.pid = pid
+        self.returncode = None
+
+    def poll(self):
+        return self.returncode
+
+    def terminate(self) -> None:
+        self.returncode = 0
+
+
+
+def launch(tmp_path: Path) -> EngineLaunch:
+    model = tmp_path / "model"
+    model.mkdir()
+    (model / "config.json").write_text("{}")
+    executable = tmp_path / "python"
+    executable.write_text("python")
+    executable.chmod(0o755)
+    return EngineLaunch(
+        engine_id="mlx",
+        model_id="qwen3-8-27b-uncensored-mlx-8bit",
+        model_path=model,
+        port=18081,
+        context_length=262_144,
+        bind_host="127.0.0.1",
+        upstream_model_id=str(model),
+        command=(
+            str(executable),
+            "-m",
+            "mlx_lm",
+            "server",
+            "--model",
+            str(model),
+            "--host",
+            "127.0.0.1",
+            "--port",
+            "18081",
+        ),
+    )
+
+
+def test_owned_engine_is_published_only_after_exact_model_readiness(tmp_path: Path) -> None:
+    spec = launch(tmp_path)
+    state = tmp_path / "owned.json"
+    process = FakeProcess()
+    calls: list[tuple[str, ...]] = []
+    observed_command = ("/real/Python", *spec.command[1:])
+    listeners = iter(((), (process.pid,)))
+
+    runtime = ManagedEngineRuntime(
+        state_path=state,
+        process_factory=lambda command, **_kwargs: calls.append(tuple(command)) or process,
+        command_line=lambda _pid: " ".join(observed_command),
+        listener_pids=lambda _port: next(listeners),
+        json_get=lambda url, _timeout: (
+            {"status": "ok"}
+            if url.endswith("/health")
+            else {"data": [{"id": spec.upstream_model_id}]}
+        ),
+        sleep=lambda _seconds: None,
+        clock=iter((0.0, 0.0)).__next__,
+    )
+
+    resident = runtime.start_owned(spec, timeout_s=1.0)
+
+    assert resident.owned is True
+    assert resident.pid == process.pid
+    assert calls == [spec.command]
+    persisted = json.loads(state.read_text())
+    assert persisted["model_id"] == spec.model_id
+    assert persisted["command"] == list(observed_command)
+
+
+def test_wrong_upstream_model_never_becomes_owned_or_routable(tmp_path: Path) -> None:
+    spec = launch(tmp_path)
+    process = FakeProcess()
+    runtime = ManagedEngineRuntime(
+        state_path=tmp_path / "owned.json",
+        process_factory=lambda _command, **_kwargs: process,
+        listener_pids=lambda _port: (),
+        command_line=lambda _pid: " ".join(spec.command),
+        json_get=lambda url, _timeout: (
+            {"status": "ok"}
+            if url.endswith("/health")
+            else {"data": [{"id": "another-model"}]}
+        ),
+        sleep=lambda _seconds: None,
+        clock=iter((0.0, 2.0)).__next__,
+    )
+
+    with pytest.raises(RuntimeError, match="did not become ready"):
+        runtime.start_owned(spec, timeout_s=1.0)
+
+    assert not (tmp_path / "owned.json").exists()
+
+
+def test_malformed_models_response_fails_closed_as_not_ready(tmp_path: Path) -> None:
+    spec = launch(tmp_path)
+    process = FakeProcess()
+    runtime = ManagedEngineRuntime(
+        state_path=tmp_path / "owned.json",
+        process_factory=lambda _command, **_kwargs: process,
+        listener_pids=lambda _port: (),
+        json_get=lambda _url, _timeout: [],
+        sleep=lambda _seconds: None,
+        clock=iter((0.0, 2.0)).__next__,
+    )
+
+    with pytest.raises(RuntimeError, match="did not become ready"):
+        runtime.start_owned(spec, timeout_s=1.0)
+
+
+def test_external_engine_is_never_signalled(tmp_path: Path) -> None:
+    spec = launch(tmp_path)
+    signalled: list[tuple[int, int]] = []
+    runtime = ManagedEngineRuntime(
+        state_path=tmp_path / "owned.json",
+        command_line=lambda _pid: "external mtplx serve --port 18081",
+        listener_pids=lambda _port: (999,),
+        signal_process=lambda pid, signal: signalled.append((pid, signal)),
+        json_get=lambda url, _timeout: (
+            {"ok": True, "model": spec.model_id}
+            if url.endswith("/health")
+            else {"data": [{"id": spec.upstream_model_id}]}
+        ),
+    )
+
+    resident = runtime.adopt_external(spec, pid=999)
+
+    assert resident.owned is False
+    assert runtime.stop() is True
+    assert signalled == []
+    assert not (tmp_path / "owned.json").exists()
+
+
+def test_external_adoption_requires_reported_pid_to_own_the_listener(tmp_path: Path) -> None:
+    spec = launch(tmp_path)
+    runtime = ManagedEngineRuntime(
+        state_path=tmp_path / "owned.json",
+        listener_pids=lambda _port: (998,),
+        json_get=lambda url, _timeout: (
+            {"status": "ok"}
+            if url.endswith("/health")
+            else {"data": [{"id": spec.upstream_model_id}]}
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="does not own"):
+        runtime.adopt_external(spec, pid=999)
+
+
+def test_recovered_pid_must_still_match_full_recorded_command(tmp_path: Path) -> None:
+    assert not ManagedEngineRuntime._command_matches(
+        ("python", "-m", "server", "--port", "18081"),
+        "python --port 18081 -m server",
+    )
+    spec = launch(tmp_path)
+    state = tmp_path / "owned.json"
+    state.write_text(json.dumps({
+        "schema": "turbofit.managed-engine/v1",
+        "engine_id": spec.engine_id,
+        "model_id": spec.model_id,
+        "model_path": str(spec.model_path),
+        "port": spec.port,
+        "context_length": spec.context_length,
+        "bind_host": spec.bind_host,
+        "upstream_model_id": spec.upstream_model_id,
+        "pid": 4321,
+        "command": list(spec.command),
+        "owned": True,
+        "status": "ready",
+    }))
+    signalled: list[tuple[int, int]] = []
+    runtime = ManagedEngineRuntime(
+        state_path=state,
+        command_line=lambda _pid: "python -m unrelated --port 18081",
+        signal_process=lambda pid, signal: signalled.append((pid, signal)),
+    )
+
+    assert runtime.stop() is False
+    assert signalled == []
+    assert state.exists()
+    assert json.loads(state.read_text())["status"] == "command-mismatch"
+
+
+def test_lifecycle_lock_serializes_cross_process_start_and_stop(tmp_path: Path) -> None:
+    runtime = ManagedEngineRuntime(state_path=tmp_path / "owned.json")
+
+    with runtime._lifecycle_lock():
+        with runtime.lock_path.open("a+") as contender:
+            with pytest.raises(BlockingIOError):
+                fcntl.flock(contender.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+
+
+def test_owned_start_refuses_an_occupied_port_before_spawning(tmp_path: Path) -> None:
+    spec = launch(tmp_path)
+    spawned: list[tuple[str, ...]] = []
+    runtime = ManagedEngineRuntime(
+        state_path=tmp_path / "owned.json",
+        process_factory=lambda command, **_kwargs: spawned.append(tuple(command)),
+        listener_pids=lambda _port: (999,),
+    )
+
+    with pytest.raises(RuntimeError, match="already occupied"):
+        runtime.start_owned(spec)
+
+    assert spawned == []
+
+
+def test_readiness_requires_the_launched_pid_to_own_the_listener(tmp_path: Path) -> None:
+    spec = launch(tmp_path)
+    process = FakeProcess()
+    listeners = iter(((), (999,), (999,)))
+    runtime = ManagedEngineRuntime(
+        state_path=tmp_path / "owned.json",
+        process_factory=lambda _command, **_kwargs: process,
+        command_line=lambda _pid: " ".join(spec.command),
+        listener_pids=lambda _port: next(listeners, (999,)),
+        json_get=lambda url, _timeout: (
+            {"status": "ok"}
+            if url.endswith("/health")
+            else {"data": [{"id": spec.upstream_model_id}]}
+        ),
+        sleep=lambda _seconds: None,
+        clock=iter((0.0, 0.0, 0.0, 2.0)).__next__,
+    )
+
+    with pytest.raises(RuntimeError, match="did not become ready"):
+        runtime.start_owned(spec, timeout_s=1.0)
+
+    assert process.returncode == 0
+
+
+def test_non_loopback_bind_is_rejected_even_if_another_argument_mentions_localhost(
+    tmp_path: Path,
+) -> None:
+    spec = launch(tmp_path)
+    with pytest.raises(ValueError, match="loopback"):
+        EngineLaunch(
+            **{
+                **spec.__dict__,
+                "bind_host": "0.0.0.0",
+                "command": (*spec.command, "/tmp/localhost-cache"),
+            }
+        )
+
+
+def test_owned_stop_waits_for_verified_process_exit(tmp_path: Path) -> None:
+    spec = launch(tmp_path)
+    state = tmp_path / "owned.json"
+    state.write_text(json.dumps({
+        "schema": "turbofit.managed-engine/v1",
+        "engine_id": spec.engine_id,
+        "model_id": spec.model_id,
+        "model_path": str(spec.model_path),
+        "port": spec.port,
+        "context_length": spec.context_length,
+        "bind_host": spec.bind_host,
+        "upstream_model_id": spec.upstream_model_id,
+        "pid": 77,
+        "command": list(spec.command),
+        "owned": True,
+        "status": "ready",
+    }))
+    observed = iter((" ".join(spec.command), " ".join(spec.command), ""))
+    signals: list[tuple[int, int]] = []
+    sleeps: list[float] = []
+    runtime = ManagedEngineRuntime(
+        state_path=state,
+        command_line=lambda _pid: next(observed, ""),
+        signal_process=lambda pid, sig: signals.append((pid, sig)),
+        sleep=lambda seconds: sleeps.append(seconds),
+        clock=iter((0.0, 0.0, 0.1)).__next__,
+    )
+
+    assert runtime.stop(timeout_s=5.0) is True
+    assert len(signals) == 1
+    assert sleeps
+    assert not state.exists()
+
+
+def test_status_reports_stale_state_instead_of_treating_file_existence_as_health(
+    tmp_path: Path,
+) -> None:
+    spec = launch(tmp_path)
+    state = tmp_path / "owned.json"
+    state.write_text(json.dumps({
+        "schema": "turbofit.managed-engine/v1",
+        "engine_id": spec.engine_id,
+        "model_id": spec.model_id,
+        "model_path": str(spec.model_path),
+        "port": spec.port,
+        "context_length": spec.context_length,
+        "bind_host": spec.bind_host,
+        "upstream_model_id": spec.upstream_model_id,
+        "pid": 77,
+        "command": list(spec.command),
+        "owned": True,
+        "status": "ready",
+    }))
+    runtime = ManagedEngineRuntime(
+        state_path=state,
+        command_line=lambda _pid: "",
+        listener_pids=lambda _port: (),
+    )
+
+    result = runtime.inspect()
+
+    assert result["ok"] is False
+    assert result["status"] == "stale"
+    assert state.exists()
+
+
+def test_engine_routes_use_real_upstream_model_id_and_shared_aux(tmp_path: Path) -> None:
+    spec = launch(tmp_path)
+    path = tmp_path / "runtime-state.json"
+
+    publish_engine_routes(path, spec)
+
+    payload = json.loads(path.read_text())
+    assert payload["active"] == "apple-mlx"
+    assert payload["routes"] == {
+        "main": {
+            "kind": "local",
+            "alias": spec.model_id,
+            "model_id": spec.upstream_model_id,
+            "port": 18081,
+            "context_length": 262_144,
+            "engine": "mlx",
+        },
+        "aux": {"kind": "shared-main", "context_length": 262_144},
+    }

--- a/tests/test_mlx_runtime_cli.py
+++ b/tests/test_mlx_runtime_cli.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+from types import SimpleNamespace
+
+
+ROOT = Path(__file__).parents[1]
+SCRIPT = ROOT / "scripts/turbofit-mlx-runtime"
+
+
+def load_script():
+    loader = SourceFileLoader("turbofit_mlx_runtime", str(SCRIPT))
+    spec = importlib.util.spec_from_loader(loader.name, loader)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class Runtime:
+    def __init__(self) -> None:
+        self.started = []
+        self.stopped = 0
+
+    def start_owned(self, launch, *, timeout_s):
+        self.started.append((launch, timeout_s))
+        return SimpleNamespace(pid=42, owned=True)
+
+    def stop(self):
+        self.stopped += 1
+        return True
+
+
+def test_start_publishes_routes_only_after_runtime_verifies(tmp_path: Path) -> None:
+    module = load_script()
+    runtime = Runtime()
+    routes = tmp_path / "routes.json"
+    model_root = tmp_path / "models"
+    runtime_root = tmp_path / "runtimes"
+
+    result = module.run_action(
+        "start",
+        runtime=runtime,
+        model_root=model_root,
+        runtime_root=runtime_root,
+        routes_path=routes,
+        port=18081,
+        timeout_s=30,
+    )
+
+    assert result == {"ok": True, "action": "start", "pid": 42, "owned": True}
+    assert runtime.started[0][1] == 30
+    assert json.loads(routes.read_text())["active"] == "apple-mlx"
+
+
+def test_stop_removes_only_the_apple_mlx_route(tmp_path: Path) -> None:
+    module = load_script()
+    runtime = Runtime()
+    routes = tmp_path / "routes.json"
+    routes.write_text(json.dumps({"active": "apple-mlx", "routes": {}}))
+
+    result = module.run_action(
+        "stop",
+        runtime=runtime,
+        model_root=tmp_path / "models",
+        runtime_root=tmp_path / "runtimes",
+        routes_path=routes,
+        port=18081,
+        timeout_s=30,
+    )
+
+    assert result == {"ok": True, "action": "stop"}
+    assert runtime.stopped == 1
+    assert not routes.exists()
+
+
+def test_cli_reexecutes_from_legacy_system_python_before_importing_runtime(tmp_path: Path) -> None:
+    system_python = Path("/usr/bin/python3")
+    if not system_python.exists():
+        return
+    result = subprocess.run(
+        [str(system_python), str(SCRIPT), "status", "--state", str(tmp_path / "missing.json")],
+        text=True,
+        capture_output=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert "unsupported operand type" not in result.stderr
+    assert json.loads(result.stdout)["action"] == "status"

--- a/tests/test_mlx_runtime_installer.py
+++ b/tests/test_mlx_runtime_installer.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).parents[1]
+SCRIPT = ROOT / "scripts/install-mlx-runtime"
+
+
+def load_script():
+    loader = SourceFileLoader("install_mlx_runtime", str(SCRIPT))
+    spec = importlib.util.spec_from_loader(loader.name, loader)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_installer_creates_isolated_pinned_mlx_runtime(tmp_path: Path) -> None:
+    module = load_script()
+    calls: list[list[str]] = []
+
+    def run(command, **_kwargs):
+        calls.append(list(command))
+        if command[1] == "venv":
+            python = tmp_path / "mlx-lm-0.31.3/.venv/bin/python"
+            python.parent.mkdir(parents=True)
+            python.write_text("python")
+            python.chmod(0o755)
+
+    record = module.install(
+        runtime_root=tmp_path,
+        uv="/opt/homebrew/bin/uv",
+        platform_name="darwin",
+        architecture="arm64",
+        run=run,
+        version_probe=lambda _python: {"mlx": "0.32.2", "mlx-lm": "0.31.3"},
+    )
+
+    python = tmp_path / "mlx-lm-0.31.3/.venv/bin/python"
+    assert calls == [
+        [
+            "/opt/homebrew/bin/uv",
+            "venv",
+            "--python",
+            "3.12",
+            str(tmp_path / "mlx-lm-0.31.3/.venv"),
+        ],
+        [
+            "/opt/homebrew/bin/uv",
+            "pip",
+            "install",
+            "--python",
+            str(python),
+            "mlx==0.32.2",
+            "mlx-lm==0.31.3",
+        ],
+    ]
+    assert record["status"] == "verified"
+    assert record["python"] == str(python)
+
+
+def test_installer_fails_closed_off_apple_silicon(tmp_path: Path) -> None:
+    module = load_script()
+
+    with pytest.raises(RuntimeError, match="Apple Silicon"):
+        module.install(
+            runtime_root=tmp_path,
+            uv="uv",
+            platform_name="linux",
+            architecture="x86_64",
+        )
+
+
+def test_installer_help_bootstraps_from_legacy_system_python() -> None:
+    system_python = Path("/usr/bin/python3")
+    if not system_python.exists():
+        return
+    result = subprocess.run(
+        [str(system_python), str(SCRIPT), "--help"],
+        text=True,
+        capture_output=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert "unsupported operand type" not in result.stderr
+    assert "Install or verify" in result.stdout

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -6,6 +6,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 
 ROOT = Path(__file__).parents[1]
 
@@ -448,6 +450,176 @@ def test_apply_configuration_can_install_lemonade_runtime(monkeypatch) -> None:
     assert result["lemonade"] == {"status": "verified", "version": "11.5.1"}
 
 
+def test_apply_configuration_activates_managed_apple_mlx_stack(monkeypatch) -> None:
+    import types
+    import plugin_tools
+    from turbofit_runtime.hardware import AcceleratorDevice, HardwareFingerprint
+
+    hardware = HardwareFingerprint(
+        os="darwin",
+        architecture="arm64",
+        system_ram_mb=128 * 1024,
+        devices=(AcceleratorDevice(
+            index=0,
+            uuid="apple-unified-memory",
+            name="Apple Silicon Unified Memory",
+            vendor="apple",
+            backend="metal",
+            memory_total_mb=120 * 1024,
+            compute_capability=None,
+            bus_id=None,
+        ),),
+    )
+    hermes_package = types.ModuleType("hermes_cli")
+    hermes_config = types.ModuleType("hermes_cli.config")
+    setattr(hermes_config, "load_config", lambda: {})
+    setattr(hermes_config, "save_config", lambda *_args, **_kwargs: None)
+    monkeypatch.setitem(sys.modules, "hermes_cli", hermes_package)
+    monkeypatch.setitem(sys.modules, "hermes_cli.config", hermes_config)
+    monkeypatch.setattr(plugin_tools, "probe_hardware", lambda: hardware, raising=False)
+    monkeypatch.setattr(
+        plugin_tools,
+        "ensure_recommended_models",
+        lambda **kwargs: {"ok": True, "families": kwargs["families"], "artifacts": []},
+    )
+    monkeypatch.setattr(
+        plugin_tools,
+        "install_mlx_runtime",
+        lambda: {"status": "verified", "versions": {"mlx-lm": "0.31.3"}},
+        raising=False,
+    )
+    monkeypatch.setattr(
+        plugin_tools,
+        "activate_apple_mlx_stack",
+        lambda: {"ok": True, "engine": "mlx", "gateway": "ready"},
+        raising=False,
+    )
+    monkeypatch.setattr(
+        plugin_tools,
+        "select_profile",
+        lambda _profile: (_ for _ in ()).throw(AssertionError("GGUF profile must not be selected")),
+    )
+
+    result = plugin_tools.apply_configuration(
+        primary=False,
+        fallback=None,
+        profile="auto",
+        base_url=None,
+        install_native=True,
+    )
+
+    assert result["models"]["families"] == ["qwen3-8-27b-uncensored-mlx-8bit"]
+    assert result["mlx_runtime"]["status"] == "verified"
+    assert result["selection"]["engine"] == "mlx"
+
+
+def test_apply_configuration_requires_explicit_native_install_for_apple_mlx(monkeypatch) -> None:
+    import types
+    import plugin_tools
+    from turbofit_runtime.hardware import AcceleratorDevice, HardwareFingerprint
+
+    hardware = HardwareFingerprint(
+        os="darwin", architecture="arm64", system_ram_mb=128 * 1024,
+        devices=(AcceleratorDevice(
+            index=0, uuid="apple-unified-memory", name="Apple Unified Memory",
+            vendor="apple", backend="metal", memory_total_mb=120 * 1024,
+            compute_capability=None, bus_id=None,
+        ),),
+    )
+    hermes_package = types.ModuleType("hermes_cli")
+    hermes_config = types.ModuleType("hermes_cli.config")
+    setattr(hermes_config, "load_config", lambda: {})
+    setattr(hermes_config, "save_config", lambda *_args, **_kwargs: None)
+    monkeypatch.setitem(sys.modules, "hermes_cli", hermes_package)
+    monkeypatch.setitem(sys.modules, "hermes_cli.config", hermes_config)
+    monkeypatch.setattr(plugin_tools, "probe_hardware", lambda: hardware)
+    monkeypatch.setattr(
+        plugin_tools,
+        "ensure_recommended_models",
+        lambda **_kwargs: (_ for _ in ()).throw(AssertionError("must fail before download")),
+    )
+
+    with pytest.raises(ValueError, match="install_native=true"):
+        plugin_tools.apply_configuration(
+            primary=False, fallback=None, profile="auto", base_url=None,
+        )
+
+
+def test_apply_configuration_blocks_unpinned_lower_memory_apple_mlx(monkeypatch) -> None:
+    import types
+    import plugin_tools
+    from turbofit_runtime.hardware import AcceleratorDevice, HardwareFingerprint
+
+    hardware = HardwareFingerprint(
+        os="darwin", architecture="arm64", system_ram_mb=32 * 1024,
+        devices=(AcceleratorDevice(
+            index=0, uuid="apple-unified-memory", name="Apple Unified Memory",
+            vendor="apple", backend="metal", memory_total_mb=30 * 1024,
+            compute_capability=None, bus_id=None,
+        ),),
+    )
+    hermes_package = types.ModuleType("hermes_cli")
+    hermes_config = types.ModuleType("hermes_cli.config")
+    setattr(hermes_config, "load_config", lambda: {})
+    setattr(hermes_config, "save_config", lambda *_args, **_kwargs: None)
+    monkeypatch.setitem(sys.modules, "hermes_cli", hermes_package)
+    monkeypatch.setitem(sys.modules, "hermes_cli.config", hermes_config)
+    monkeypatch.setattr(plugin_tools, "probe_hardware", lambda: hardware)
+    monkeypatch.setattr(
+        plugin_tools,
+        "ensure_recommended_models",
+        lambda **_kwargs: (_ for _ in ()).throw(AssertionError("must fail before download")),
+    )
+
+    with pytest.raises(RuntimeError, match="not pinned"):
+        plugin_tools.apply_configuration(
+            primary=False, fallback=None, profile="auto", base_url=None,
+            install_native=True,
+        )
+
+
+def test_apple_mlx_activation_failure_restores_previous_hermes_config(monkeypatch) -> None:
+    import types
+    import plugin_tools
+    from turbofit_runtime.hardware import AcceleratorDevice, HardwareFingerprint
+
+    hardware = HardwareFingerprint(
+        os="darwin", architecture="arm64", system_ram_mb=128 * 1024,
+        devices=(AcceleratorDevice(
+            index=0, uuid="apple-unified-memory", name="Apple Unified Memory",
+            vendor="apple", backend="metal", memory_total_mb=120 * 1024,
+            compute_capability=None, bus_id=None,
+        ),),
+    )
+    original = {"model": {"default": "old-model", "provider": "old-provider"}}
+    saved = []
+    hermes_package = types.ModuleType("hermes_cli")
+    hermes_config = types.ModuleType("hermes_cli.config")
+    setattr(hermes_config, "load_config", lambda: original)
+    setattr(hermes_config, "save_config", lambda value, **_kwargs: saved.append(value))
+    monkeypatch.setitem(sys.modules, "hermes_cli", hermes_package)
+    monkeypatch.setitem(sys.modules, "hermes_cli.config", hermes_config)
+    monkeypatch.setattr(plugin_tools, "probe_hardware", lambda: hardware)
+    monkeypatch.setattr(
+        plugin_tools, "ensure_recommended_models",
+        lambda **kwargs: {"ok": True, "families": kwargs["families"], "artifacts": []},
+    )
+    monkeypatch.setattr(plugin_tools, "install_mlx_runtime", lambda: {"status": "verified"})
+    monkeypatch.setattr(
+        plugin_tools, "activate_apple_mlx_stack",
+        lambda: (_ for _ in ()).throw(RuntimeError("activation failed")),
+    )
+
+    with pytest.raises(RuntimeError, match="activation failed"):
+        plugin_tools.apply_configuration(
+            primary=True, fallback=None, profile="auto", base_url=None,
+            install_native=True,
+        )
+
+    assert len(saved) == 2
+    assert saved[-1] == original
+
+
 def test_apply_configuration_can_install_native_runtime(monkeypatch) -> None:
     import types
     import plugin_tools
@@ -864,3 +1036,30 @@ def test_select_profile_skips_systemctl_on_windows(monkeypatch) -> None:
     assert payload["configured"] is True
     assert payload["controller_restarted"] is False
     assert all(command[0] != "systemctl" for command in seen)
+
+
+def test_recommended_artifacts_follow_apple_mlx_lane() -> None:
+    import plugin_tools
+    from turbofit_runtime.hardware import AcceleratorDevice, HardwareFingerprint
+
+    hardware = HardwareFingerprint(
+        os="darwin",
+        architecture="arm64",
+        system_ram_mb=128 * 1024,
+        devices=(
+            AcceleratorDevice(
+                index=0,
+                uuid="apple-unified-memory",
+                name="Apple Silicon Unified Memory",
+                vendor="apple",
+                backend="metal",
+                memory_total_mb=120 * 1024,
+                compute_capability=None,
+                bus_id=None,
+            ),
+        ),
+    )
+
+    assert plugin_tools.recommended_artifact_families(hardware=hardware) == [
+        "qwen3-8-27b-uncensored-mlx-8bit"
+    ]

--- a/tests/test_release_version.py
+++ b/tests/test_release_version.py
@@ -49,3 +49,15 @@ def test_readme_qwen_variants_match_active_catalog() -> None:
     readme = (ROOT / "README.md").read_text()
     assert "Qwen 3.8 27B Unleashed" in readme
     assert "Ornith 1.5 35A3B" in readme
+
+
+def test_distribution_includes_managed_apple_mlx_runtime_files() -> None:
+    distribution = yaml.safe_load((ROOT / "distribution.yaml").read_text())
+    owned = set(distribution["distribution_owned"])
+
+    assert {
+        "references/python-runtimes.json",
+        "scripts/install-mlx-runtime",
+        "scripts/turbofit-gateway-runtime",
+        "scripts/turbofit-mlx-runtime",
+    } <= owned


### PR DESCRIPTION
Title: Add managed Apple MLX runtime for Qwen 3.8 27B

Base: main @ 98b45598785c4ca8efe5a5d5ea0835782f4ee007
Head: feat/apple-mlx-runtime @ 5696b84a6b3d25c61e09ea11451ec2225491422c

Summary

Complete the existing Apple MLX recommendation as an owned, loopback-only runtime lane. This pins and verifies the recommended OrcaRouter Qwen 3.8 27B 8-bit snapshot, installs an isolated MLX/MLX-LM environment, starts and verifies the model and Turbofit gateway, publishes stable auto/active routes, and rolls back failed activation.

Problem

Current source recommends `orcarouter/Qwen3.8-27B-Uncensored-MLX` on Apple Silicon but only probes for a generic MLX installation. It does not pin/download the selected snapshot, own its process, verify exact model identity, publish a managed route, or provide safe stop/recovery behavior.

Implementation

- Pin MLX 0.32.2 and MLX-LM 0.31.3 in an isolated runtime.
- Pin every file, size, and SHA-256 in the complete 8-bit model snapshot at revision `b4603df5fd2a51e7fed2560ee7090caa4e13e4b7`.
- Add explicit Apple MLX install and model/gateway lifecycle CLIs.
- Add a shared managed-engine lifecycle with:
  - parsed loopback binding;
  - occupied-port refusal;
  - listening-PID ownership verification;
  - cross-process lifecycle locking;
  - exact normalized argv verification before signalling;
  - explicit launching/ready/stale/mismatch/timeout states;
  - verified shutdown and retained forensic state on failure.
- Verify the exact upstream model ID from `/v1/models` before route publication and during gateway routing.
- Keep stable client IDs `auto`, `active:main`, and `active:aux` while forwarding the backend's real model ID.
- Require explicit `install_native=true` before downloading/starting Apple MLX.
- Fail closed for currently unpinned 4-bit and 6-bit Apple recommendations.
- Save Hermes configuration before activation and restore it if activation fails.
- Include all new runtime files in the plugin distribution.

Safety

- Every managed endpoint binds to `127.0.0.1`.
- A busy port is never adopted implicitly.
- Turbofit signals only an exact PID + argv + listener match it recorded as owned.
- Command mismatch and stop/cleanup timeout preserve state rather than claiming success.
- Gateway requests fail closed if a healthy listener advertises a different model.
- No credentials, user paths, process IDs, or private logs are included in committed evidence.

Measured Apple evidence

Exact test machine: Apple M5 Max, 128 GiB unified memory, macOS 26.6.1.

- Basic screening: pass; instruction 1.0; context 1.0; 15.494402 effective output tok/s.
- Extended 8K/32K/64K passkey suite: pass; context 1.0; 17.968452 effective output tok/s.
- Matched 512-token coding run: 17.306976 end-to-end tok/s.
- Peak unified memory in extended suite: 63,631 MiB.
- Generic MLX responses did not expose server-side TTFT, so no TTFT is inferred.

Evidence: `references/results/apple-m5-max-generic-mlx-20260830.json`.

Verification

- Focused clean-worktree suite: 117 passed; 2 known baseline tests deselected.
- Broader local feature suite before split: 99 passed.
- Managed lifecycle suite: 13 passed.
- Real local smoke through Turbofit `auto`: `LOCAL_HARDENED_OK`.
- Model and gateway status both verified `ready`; ports 18081 and 8091 verified released after stop.
- `git diff --check`: pass.

Repository baseline

`scripts/release-check` remains non-green on this checkout because current `main` already has 15 failing tests on this Mac. This branch has 14 failures, all among the same baseline set; it fixes the stale artifact-manifest count/identity gate and introduces no new full-suite failure. The post-test link gate also fails identically on current `main` because several docs use repository-root-relative links while the checker resolves them relative to each document.

Out of scope

- MTPLX support (stacked separately).
- Automatic promotion based on one machine.
- Claims for 4-bit/6-bit Apple variants.
- Cloud/API fallback or public-network serving.
