### PR TITLE
Add MTPLX runtime adapter for Apple Silicon

### DIFF
--- a/desktop/plugin.js
+++ b/desktop/plugin.js
@@ -587,7 +587,7 @@ function TurbofitPage() {
         }),
         jsxs('label', { className: 'flex items-center gap-2', children: [
           jsx('input', { type: 'checkbox', checked: installNative, onChange: (event) => setInstallNative(event.target.checked) }),
-          'Install or verify the native adaptive runtime',
+          'Install and activate the native runtime (downloads the selected model and starts local processes)',
         ] }),
         jsxs('label', { className: 'flex items-center gap-2', children: [
           jsx('input', { type: 'checkbox', checked: installFreeToken, onChange: (event) => setInstallFreeToken(event.target.checked) }),

--- a/distribution.yaml
+++ b/distribution.yaml
@@ -59,6 +59,9 @@ distribution_owned:
   - scripts/build-promo-video
   - scripts/download-models.py
   - scripts/download-artifacts
+  - scripts/install-mlx-runtime
+  - scripts/turbofit-gateway-runtime
+  - scripts/turbofit-mlx-runtime
   - scripts/install-dspark-runtime
   - scripts/install-lemonade-runtime
   - scripts/install-macos-native-service
@@ -79,11 +82,13 @@ distribution_owned:
 
   - references/model-recipes.json
   - references/artifact-manifest.json
+  - references/python-runtimes.json
   - references/hardware-tier-tournaments.json
   - references/auxiliary-tier-recommendations.json
   - references/intelligence-scores.json
   - references/external-benchmarks.md
 
-# Installation does not start launchers, watchers, or modify provider credentials.
-# Runtime activation remains an explicit Turbofile selection.
+# Plugin installation alone does not start launchers, watchers, or modify provider
+# credentials. Explicit install_native setup may install a selected model and start
+# its loopback runtime and provider gateway.
 post_install: []

--- a/distribution.yaml
+++ b/distribution.yaml
@@ -62,6 +62,7 @@ distribution_owned:
   - scripts/install-mlx-runtime
   - scripts/turbofit-gateway-runtime
   - scripts/turbofit-mlx-runtime
+  - scripts/turbofit-mtplx-runtime
   - scripts/install-dspark-runtime
   - scripts/install-lemonade-runtime
   - scripts/install-macos-native-service

--- a/plugin_tools.py
+++ b/plugin_tools.py
@@ -307,12 +307,101 @@ def install_native_runtime(backend: str = "auto") -> dict[str, Any]:
     return payload
 
 
-def recommended_artifact_families(usable_memory_mb: int | None = None) -> list[str]:
-    """Auto-chain families for this machine, plus default Ornith auxiliary."""
-    if usable_memory_mb is None:
+def probe_hardware():
+    """Profile-local seam for deterministic setup tests and platform routing."""
+    from turbofit_runtime.hardware import probe_hardware as probe
+
+    return probe()
+
+
+def _apple_mlx_hardware(hardware) -> bool:
+    devices = tuple(getattr(hardware, "devices", ()) or ())
+    return any(
+        getattr(device, "vendor", "") == "apple"
+        or getattr(device, "backend", "") == "metal"
+        for device in devices
+    )
+
+
+def install_mlx_runtime() -> dict[str, Any]:
+    script = PLUGIN_ROOT / "scripts" / "install-mlx-runtime"
+    result = subprocess.run(
+        [str(script), "--json"],
+        text=True,
+        capture_output=True,
+        timeout=1800,
+        check=False,
+    )
+    try:
+        payload = json.loads(result.stdout or result.stderr)
+    except ValueError as exc:
+        raise RuntimeError((result.stdout or result.stderr).strip() or "MLX install failed") from exc
+    if result.returncode:
+        raise RuntimeError(payload.get("error") or "MLX install failed")
+    return payload
+
+
+def activate_apple_mlx_stack() -> dict[str, Any]:
+    model_script = PLUGIN_ROOT / "scripts" / "turbofit-mlx-runtime"
+    gateway_script = PLUGIN_ROOT / "scripts" / "turbofit-gateway-runtime"
+    model = subprocess.run(
+        [str(model_script), "start"],
+        text=True,
+        capture_output=True,
+        timeout=1200,
+        check=False,
+    )
+    if model.returncode:
+        raise RuntimeError((model.stderr or model.stdout or "MLX runtime failed").strip())
+    gateway = subprocess.run(
+        [str(gateway_script), "start"],
+        text=True,
+        capture_output=True,
+        timeout=180,
+        check=False,
+    )
+    if gateway.returncode:
+        subprocess.run([str(model_script), "stop"], check=False, timeout=60)
+        raise RuntimeError((gateway.stderr or gateway.stdout or "gateway failed").strip())
+    return {
+        "ok": True,
+        "engine": "mlx",
+        "model": json.loads(model.stdout),
+        "gateway": json.loads(gateway.stdout),
+    }
+
+
+def recommended_artifact_families(
+    usable_memory_mb: int | None = None,
+    *,
+    hardware=None,
+) -> list[str]:
+    """Return artifacts for the machine's actual memory pool and engine lane."""
+    if hardware is None and usable_memory_mb is None:
         from turbofit_runtime.hardware import probe_hardware
 
-        usable_memory_mb = int(probe_hardware().total_usable_memory_mb)
+        hardware = probe_hardware()
+    if hardware is not None:
+        devices = tuple(getattr(hardware, "devices", ()) or ())
+        backend = str(getattr(devices[0], "backend", "") if devices else "")
+        vendor = str(getattr(devices[0], "vendor", "") if devices else "")
+        if backend == "metal" or vendor == "apple":
+            from turbofit_runtime.allowed_lineup import check_local_options
+
+            options = check_local_options(
+                vram_gb=0,
+                host_ram_gb=float(hardware.system_ram_mb) / 1024,
+                memory_pool="unified",
+                backend=backend or "metal",
+                vendor=vendor or "apple",
+            )
+            mains = [str(item["alias"]) for item in options if item.get("role") == "main"]
+            if not mains:
+                raise RuntimeError("Apple MLX recommendation produced no main model")
+            return [mains[0]]
+        usable_memory_mb = int(hardware.total_usable_memory_mb)
+    if usable_memory_mb is None:
+        raise ValueError("usable memory or hardware is required")
     if usable_memory_mb < 16 * 1024:
         main = "maple-preview-tq2"
     elif usable_memory_mb < 24 * 1024:
@@ -1076,13 +1165,27 @@ def apply_configuration(
     from hermes_cli.config import load_config, save_config
 
     with _CONFIG_LOCK:
+        hardware = probe_hardware()
+        apple_hardware = profile == "auto" and _apple_mlx_hardware(hardware)
+        families = recommended_artifact_families(hardware=hardware) if apple_hardware else None
+        apple_family = families[0] if families else None
+        apple_mlx = apple_family == "qwen3-8-27b-uncensored-mlx-8bit"
+        if apple_family and "-mlx-" in apple_family and not apple_mlx:
+            raise RuntimeError(
+                f"managed Apple MLX artifact is not pinned for {apple_family}; setup is blocked"
+            )
+        if apple_mlx and not install_native:
+            raise ValueError(
+                "Apple MLX auto activation requires install_native=true because it installs "
+                "the pinned runtime and starts loopback model and gateway processes"
+            )
         sirvir = install_sirvir_profile() if install_sirvir else None
         desktop = install_desktop_plugin() if install_desktop else None
         lemonade = install_lemonade_runtime() if install_lemonade else None
-        native = install_native_runtime() if install_native else None
+        native = install_native_runtime() if install_native and not apple_mlx else None
         freetoken = install_freetoken_runtime() if install_freetoken else None
-        models = ensure_recommended_models()
-        selected = select_profile(profile) if profile else None
+        models = ensure_recommended_models(families=families) if families else ensure_recommended_models()
+        mlx_runtime = install_mlx_runtime() if apple_mlx else None
         publication = (
             publish_tailnet(
                 dashboard_local_port=dashboard_local_port,
@@ -1094,8 +1197,9 @@ def apply_configuration(
             else None
         )
         effective_base_url = publication["provider_base_url"] if publication else base_url
+        original_config = load_config()
         configured = configure_hermes(
-            load_config(),
+            original_config,
             primary=primary,
             fallback=fallback,
             fallback_chain=list(NOUS_FREE_FALLBACK_CHAIN) if fallback_chain is None else fallback_chain,
@@ -1110,6 +1214,15 @@ def apply_configuration(
                 catalog=MultimodalCatalog.load(MULTIMODAL_CATALOG),
             )
         save_config(configured, merge_existing=False)
+        try:
+            selected = (
+                activate_apple_mlx_stack()
+                if apple_mlx
+                else (select_profile(profile) if profile else None)
+            )
+        except Exception:
+            save_config(original_config, merge_existing=False)
+            raise
     return {
         "ok": True,
         "configured": True,
@@ -1119,6 +1232,7 @@ def apply_configuration(
         "desktop_plugin": desktop,
         "lemonade": lemonade,
         "native_runtime": native,
+        "mlx_runtime": mlx_runtime,
         "freetoken_runtime": freetoken,
         "models": models,
         "restart_required": True,

--- a/references/artifact-manifest.json
+++ b/references/artifact-manifest.json
@@ -500,6 +500,159 @@
       "path": "maple-tq2_0.gguf",
       "sha256": "09d219202562dbd17722dc8e3273527a021182ab7f892c2a06aac459a8f3a090",
       "size_bytes": 5454482432
+    },
+    {
+      "destination": "Qwen3.8-27B-Uncensored-MLX/8-bit/README.md",
+      "families": ["qwen3-8-27b-uncensored-mlx-8bit"],
+      "repo_id": "orcarouter/Qwen3.8-27B-Uncensored-MLX",
+      "revision": "b4603df5fd2a51e7fed2560ee7090caa4e13e4b7",
+      "path": "8-bit/README.md",
+      "sha256": "9a272b5949a803ab6eadf0703706dab183229952e2b374501d1069d0f6d16557",
+      "size_bytes": 84
+    },
+    {
+      "destination": "Qwen3.8-27B-Uncensored-MLX/8-bit/chat_template.jinja",
+      "families": ["qwen3-8-27b-uncensored-mlx-8bit"],
+      "repo_id": "orcarouter/Qwen3.8-27B-Uncensored-MLX",
+      "revision": "b4603df5fd2a51e7fed2560ee7090caa4e13e4b7",
+      "path": "8-bit/chat_template.jinja",
+      "sha256": "c3cf9e34abf4f9e36c2d72165aa9c132d3e2a725b6c2586aaa3a8af9d7a81041",
+      "size_bytes": 8952
+    },
+    {
+      "destination": "Qwen3.8-27B-Uncensored-MLX/8-bit/config.json",
+      "families": ["qwen3-8-27b-uncensored-mlx-8bit"],
+      "repo_id": "orcarouter/Qwen3.8-27B-Uncensored-MLX",
+      "revision": "b4603df5fd2a51e7fed2560ee7090caa4e13e4b7",
+      "path": "8-bit/config.json",
+      "sha256": "10ee84e6bb4f99d09d3166ab85f92e5b313b8bdb9117f5db694c598173cd303b",
+      "size_bytes": 5187
+    },
+    {
+      "destination": "Qwen3.8-27B-Uncensored-MLX/8-bit/generation_config.json",
+      "families": ["qwen3-8-27b-uncensored-mlx-8bit"],
+      "repo_id": "orcarouter/Qwen3.8-27B-Uncensored-MLX",
+      "revision": "b4603df5fd2a51e7fed2560ee7090caa4e13e4b7",
+      "path": "8-bit/generation_config.json",
+      "sha256": "e70c136c1b78ddc1fb0905bac8e733a4dc448d4f852a5dd75143fffc70be550e",
+      "size_bytes": 202
+    },
+    {
+      "destination": "Qwen3.8-27B-Uncensored-MLX/8-bit/model-00001-of-00006.safetensors",
+      "families": ["qwen3-8-27b-uncensored-mlx-8bit"],
+      "repo_id": "orcarouter/Qwen3.8-27B-Uncensored-MLX",
+      "revision": "b4603df5fd2a51e7fed2560ee7090caa4e13e4b7",
+      "path": "8-bit/model-00001-of-00006.safetensors",
+      "sha256": "d8f01eded64ecd012b90a8e1375433a5ec49cd1acadb77c2ed5f8ce833af528e",
+      "size_bytes": 5317707349
+    },
+    {
+      "destination": "Qwen3.8-27B-Uncensored-MLX/8-bit/model-00002-of-00006.safetensors",
+      "families": ["qwen3-8-27b-uncensored-mlx-8bit"],
+      "repo_id": "orcarouter/Qwen3.8-27B-Uncensored-MLX",
+      "revision": "b4603df5fd2a51e7fed2560ee7090caa4e13e4b7",
+      "path": "8-bit/model-00002-of-00006.safetensors",
+      "sha256": "e90b3f8eadb473ce46d60f231d7a50f0386d4e6dcb92907cd7c99f1e75e33573",
+      "size_bytes": 5354102528
+    },
+    {
+      "destination": "Qwen3.8-27B-Uncensored-MLX/8-bit/model-00003-of-00006.safetensors",
+      "families": ["qwen3-8-27b-uncensored-mlx-8bit"],
+      "repo_id": "orcarouter/Qwen3.8-27B-Uncensored-MLX",
+      "revision": "b4603df5fd2a51e7fed2560ee7090caa4e13e4b7",
+      "path": "8-bit/model-00003-of-00006.safetensors",
+      "sha256": "1fc349c8f9411680471dd5c0f6e586958feb9cc67d7c020ed459423b7b6ea050",
+      "size_bytes": 5354184654
+    },
+    {
+      "destination": "Qwen3.8-27B-Uncensored-MLX/8-bit/model-00004-of-00006.safetensors",
+      "families": ["qwen3-8-27b-uncensored-mlx-8bit"],
+      "repo_id": "orcarouter/Qwen3.8-27B-Uncensored-MLX",
+      "revision": "b4603df5fd2a51e7fed2560ee7090caa4e13e4b7",
+      "path": "8-bit/model-00004-of-00006.safetensors",
+      "sha256": "86b4fe4b4a85620254875b52575f5a459f83f0ead952c362b9800937a2e9dba9",
+      "size_bytes": 5337309675
+    },
+    {
+      "destination": "Qwen3.8-27B-Uncensored-MLX/8-bit/model-00005-of-00006.safetensors",
+      "families": ["qwen3-8-27b-uncensored-mlx-8bit"],
+      "repo_id": "orcarouter/Qwen3.8-27B-Uncensored-MLX",
+      "revision": "b4603df5fd2a51e7fed2560ee7090caa4e13e4b7",
+      "path": "8-bit/model-00005-of-00006.safetensors",
+      "sha256": "215aa22dc0d42e96283ae624b48c6ae82173999a6ff137c575f07f825ee53975",
+      "size_bytes": 5292848520
+    },
+    {
+      "destination": "Qwen3.8-27B-Uncensored-MLX/8-bit/model-00006-of-00006.safetensors",
+      "families": ["qwen3-8-27b-uncensored-mlx-8bit"],
+      "repo_id": "orcarouter/Qwen3.8-27B-Uncensored-MLX",
+      "revision": "b4603df5fd2a51e7fed2560ee7090caa4e13e4b7",
+      "path": "8-bit/model-00006-of-00006.safetensors",
+      "sha256": "0c7e1d9fb971cf6eaea638ee8d48661abc85ed822e34f405e334b8c1ef910ff6",
+      "size_bytes": 2845065535
+    },
+    {
+      "destination": "Qwen3.8-27B-Uncensored-MLX/8-bit/model.safetensors.index.json",
+      "families": ["qwen3-8-27b-uncensored-mlx-8bit"],
+      "repo_id": "orcarouter/Qwen3.8-27B-Uncensored-MLX",
+      "revision": "b4603df5fd2a51e7fed2560ee7090caa4e13e4b7",
+      "path": "8-bit/model.safetensors.index.json",
+      "sha256": "4301ca600788afb2a45c0aa367140d6144ecf617d0a51a8187fc6755d65301f8",
+      "size_bytes": 218281
+    },
+    {
+      "destination": "Qwen3.8-27B-Uncensored-MLX/8-bit/preprocessor_config.json",
+      "families": ["qwen3-8-27b-uncensored-mlx-8bit"],
+      "repo_id": "orcarouter/Qwen3.8-27B-Uncensored-MLX",
+      "revision": "b4603df5fd2a51e7fed2560ee7090caa4e13e4b7",
+      "path": "8-bit/preprocessor_config.json",
+      "sha256": "27225450ac9c6529872ee1924fcb0962ff5634834f817040f444118116f4e516",
+      "size_bytes": 390
+    },
+    {
+      "destination": "Qwen3.8-27B-Uncensored-MLX/8-bit/processor_config.json",
+      "families": ["qwen3-8-27b-uncensored-mlx-8bit"],
+      "repo_id": "orcarouter/Qwen3.8-27B-Uncensored-MLX",
+      "revision": "b4603df5fd2a51e7fed2560ee7090caa4e13e4b7",
+      "path": "8-bit/processor_config.json",
+      "sha256": "45fc17c8dd2474af6b493b52483c26c0584b0082d368c480f9fa611e73070040",
+      "size_bytes": 991
+    },
+    {
+      "destination": "Qwen3.8-27B-Uncensored-MLX/8-bit/tokenizer.json",
+      "families": ["qwen3-8-27b-uncensored-mlx-8bit"],
+      "repo_id": "orcarouter/Qwen3.8-27B-Uncensored-MLX",
+      "revision": "b4603df5fd2a51e7fed2560ee7090caa4e13e4b7",
+      "path": "8-bit/tokenizer.json",
+      "sha256": "06b9509352d2af50381ab2247e083b80d32d5c0aba91c272ca9ff729b6a0e523",
+      "size_bytes": 19989325
+    },
+    {
+      "destination": "Qwen3.8-27B-Uncensored-MLX/8-bit/tokenizer_config.json",
+      "families": ["qwen3-8-27b-uncensored-mlx-8bit"],
+      "repo_id": "orcarouter/Qwen3.8-27B-Uncensored-MLX",
+      "revision": "b4603df5fd2a51e7fed2560ee7090caa4e13e4b7",
+      "path": "8-bit/tokenizer_config.json",
+      "sha256": "792fa3f0cb88b111e54ef3134c873531008c4df471d108da17903426e308aa7b",
+      "size_bytes": 1165
+    },
+    {
+      "destination": "Qwen3.8-27B-Uncensored-MLX/8-bit/video_preprocessor_config.json",
+      "families": ["qwen3-8-27b-uncensored-mlx-8bit"],
+      "repo_id": "orcarouter/Qwen3.8-27B-Uncensored-MLX",
+      "revision": "b4603df5fd2a51e7fed2560ee7090caa4e13e4b7",
+      "path": "8-bit/video_preprocessor_config.json",
+      "sha256": "7768af27c1fafa9cc9011c1dc20067e03f8915e03b63504550e11d5066986d13",
+      "size_bytes": 385
+    },
+    {
+      "destination": "Qwen3.8-27B-Uncensored-MLX/8-bit/vocab.json",
+      "families": ["qwen3-8-27b-uncensored-mlx-8bit"],
+      "repo_id": "orcarouter/Qwen3.8-27B-Uncensored-MLX",
+      "revision": "b4603df5fd2a51e7fed2560ee7090caa4e13e4b7",
+      "path": "8-bit/vocab.json",
+      "sha256": "ce99b4cb2983d118806ce0a8b777a35b093e2000a503ebde25853284c9dfa003",
+      "size_bytes": 6722759
     }
   ]
 }

--- a/references/python-runtimes.json
+++ b/references/python-runtimes.json
@@ -1,0 +1,14 @@
+{
+  "schema": "turbofit.python-runtimes/v1",
+  "runtimes": {
+    "mlx-lm": {
+      "version": "0.31.3",
+      "packages": {
+        "mlx": "mlx==0.32.2",
+        "mlx-lm": "mlx-lm==0.31.3"
+      },
+      "platforms": ["darwin-arm64"],
+      "entrypoint": "python -m mlx_lm server"
+    }
+  }
+}

--- a/references/results/apple-m5-max-generic-mlx-20260830.json
+++ b/references/results/apple-m5-max-generic-mlx-20260830.json
@@ -1,0 +1,72 @@
+{
+  "schema": "turbofit.apple-runtime-evidence/v1",
+  "recorded_at": "2026-08-30T21:10:45Z",
+  "tested_turbofit_commit": "98b45598785c4ca8efe5a5d5ea0835782f4ee007",
+  "classification": "measured",
+  "hardware": {
+    "model": "MacBook Pro",
+    "chip": "Apple M5 Max",
+    "architecture": "arm64",
+    "system_memory_gib": 128,
+    "accelerator": "Apple GPU",
+    "accelerator_memory_kind": "unified",
+    "os": "macOS 26.6.1"
+  },
+  "artifact": {
+    "family": "qwen3-8-27b-uncensored-mlx-8bit",
+    "repository": "orcarouter/Qwen3.8-27B-Uncensored-MLX",
+    "revision": "b4603df5fd2a51e7fed2560ee7090caa4e13e4b7",
+    "variant": "8-bit",
+    "tree_sha256": "00244f54c1c1065086ac55a39cf842e0319446a816b46509dd69bc15a7c4bd3a"
+  },
+  "runtime": {
+    "engine": "mlx-lm",
+    "mlx_version": "0.32.2",
+    "mlx_lm_version": "0.31.3",
+    "context_length": 262144,
+    "route": "http://127.0.0.1:8091/v1 model auto"
+  },
+  "screening": {
+    "status": "pass",
+    "quality_pass_rate": 1.0,
+    "context_pass_rate": 1.0,
+    "effective_output_tokens_per_second": 15.494402,
+    "measured_prompt_tokens": 1268,
+    "measured_completion_tokens": 78,
+    "peak_unified_memory_used_mib": 52415,
+    "peak_process_rss_mib": 27660,
+    "raw_evidence_sha256": "sha256:3f8dddbac063a01d747c59721e34869d0eaad0e0fd39e24c5a4f09f7e900034a"
+  },
+  "extended": {
+    "status": "pass",
+    "passkey_context_words": [8192, 32768, 65536],
+    "quality_pass_rate": 1.0,
+    "context_pass_rate": 1.0,
+    "effective_output_tokens_per_second": 17.968452,
+    "measured_prompt_tokens": 122055,
+    "measured_completion_tokens": 540,
+    "peak_unified_memory_used_mib": 63631,
+    "peak_process_rss_mib": 27673,
+    "raw_evidence_sha256": "sha256:7924d112fb9ea7d8d9b2cb6772bf94a82a8f050a11df9113d724aea18e914fda"
+  },
+  "matched_long_code": {
+    "prompt_id": "long_warm_code_continuation",
+    "prompt_sha256": "sha256:babfc7f67bd8ec7a23439467a494b5bbe54538251e67ed7d2f8678d3c15fbe91",
+    "sampler": {
+      "temperature": 1.0,
+      "top_p": 0.95,
+      "top_k": 20,
+      "seed": 0
+    },
+    "completion_tokens": 512,
+    "finish_reason": "length",
+    "elapsed_seconds": 29.583446,
+    "end_to_end_tokens_per_second": 17.306976,
+    "raw_evidence_sha256": "sha256:13890ab1da62ffa596af0cb288aa2adc80e0291ce86184a4b045fcac375e98fb"
+  },
+  "limitations": [
+    "The generic mlx-lm response did not expose a server-side TTFT metric; no TTFT value is inferred.",
+    "These measurements apply only to the exact artifact, runtime, route, and hardware above.",
+    "The matched MTPLX comparison uses different model artifacts and is an end-product comparison, not an engine-only attribution."
+  ]
+}

--- a/references/results/apple-m5-max-mtplx-20260830.json
+++ b/references/results/apple-m5-max-mtplx-20260830.json
@@ -88,11 +88,83 @@
         "quality_passed": true,
         "raw_result_sha256": "sha256:f08c2a6fd21f3f3c48b78e35a0772a22f7592ab517d2886d45240639789caa6c"
       }
+    },
+    "flash_next_bare_speed": {
+      "repository": "Youssofal/Qwen3.8-Flash-Next-MTPLX-Bare-Speed",
+      "upstream_revision_observed": "39c15cc6d45caeb4ea20e1e16e922c43fdb3e21f",
+      "local_source_manifest_sha256": "63bce5090d380de88b9fb37d05875cc2d53749d9af770856129854fc0df942e9",
+      "artifact_size_bytes": 106336816568,
+      "extended": {
+        "status": "pass",
+        "passkey_context_words": [8192, 32768, 65536],
+        "quality_pass_rate": 1.0,
+        "context_pass_rate": 1.0,
+        "effective_output_tokens_per_second": 85.343646,
+        "mean_ttft_ms": 21942.262,
+        "peak_unified_memory_used_mib": 105851,
+        "raw_evidence_sha256": "sha256:9e1d24a93f3f166d90a339a6d54c5d4bf963b5df68b355ef1a4244de0f2f6de4"
+      },
+      "depth_sweep": {
+        "prompt_id": "long_warm_code_continuation",
+        "completion_tokens_per_run": 512,
+        "ar_end_to_end_tokens_per_second": 44.963166,
+        "d1_end_to_end_tokens_per_second": 71.552248,
+        "d2_end_to_end_tokens_per_second": 95.251886,
+        "d3_end_to_end_tokens_per_second": 85.303066,
+        "d4_end_to_end_tokens_per_second": 86.392667,
+        "d5_end_to_end_tokens_per_second": 73.998435,
+        "winner": "D2",
+        "raw_evidence_sha256": {
+          "ar": "sha256:02d447543a59afd50442a211ec49c58937a9482fcdd2f9dc5fe0cef71f8f8375",
+          "d1": "sha256:c730741644f142b0cf63bff2d85cd0e8faab7000a71a7eac7ba4c5b9e88db9f7",
+          "d2": "sha256:7b7988e99a14f2a2d651a652b8259ab87695fafe6d0617f05e6d1e8e93bf6e2c",
+          "d3": "sha256:bf9d6231f47c452fba6e420419ce9fe487628cb4bb71f0ff61abadb66fbd89db",
+          "d4": "sha256:123e76c6f4173123ce0b0d0eb513871a18c22ba0f5cbf8d877d1e2394f8d3b61",
+          "d5": "sha256:d4c66f027785da01555c8fc34521c6c9aeff79deed63f764ff780595a95fcbdc"
+        }
+      }
+    },
+    "flash_next_optimized_speed": {
+      "repository": "Youssofal/Qwen3.8-Flash-Next-MTPLX-Optimized-Speed",
+      "upstream_revision_observed": "29ba90f82124961d0d902a9ea9bbb1034972af2f",
+      "local_source_manifest_sha256": "3157bb6ca92de5708c1510739f4afdd03d14cb06944e803033fcc4570734e04e",
+      "artifact_size_bytes": 115061257837,
+      "extended": {
+        "status": "pass",
+        "passkey_context_words": [8192, 32768, 65536],
+        "quality_pass_rate": 1.0,
+        "context_pass_rate": 1.0,
+        "effective_output_tokens_per_second": 85.580633,
+        "mean_ttft_ms": 22391.268,
+        "peak_unified_memory_used_mib": 113521,
+        "raw_evidence_sha256": "sha256:564779023377afd60028d0c5d5a3e33682a9392c99959365fca559e8f08a9f13"
+      },
+      "depth_sweep": {
+        "prompt_id": "long_warm_code_continuation",
+        "completion_tokens_per_run": 512,
+        "ar_end_to_end_tokens_per_second": 43.5019,
+        "d1_end_to_end_tokens_per_second": 63.454447,
+        "d2_end_to_end_tokens_per_second": 89.707503,
+        "d3_end_to_end_tokens_per_second": 90.963623,
+        "d4_end_to_end_tokens_per_second": 72.459613,
+        "d5_end_to_end_tokens_per_second": 84.138004,
+        "winner": "D3",
+        "raw_evidence_sha256": {
+          "ar": "sha256:b19d16bb4e75bfa3b6578da5bb4f545e5e6d7a76bece745c07817cfda181154c",
+          "d1": "sha256:922e77c4d64f6ee3e056356e4075c2637414f29d1b9bfc8640f38a7002db39cf",
+          "d2": "sha256:bdd374fea1d62114fff1f7827e0679900382f3f65a0f34e983564a43afb9a1e6",
+          "d3": "sha256:dfd9d31f393345c402251591d90d95191bd6ab16557d41b6c947965e976badd7",
+          "d4": "sha256:fc9502653235a64bffb0f81a80640b5cc857a3df1d065d872c0081e16ed657cb",
+          "d5": "sha256:6618a66a96f87ff7ff240d4da71f5c4b58d8356753a4ad63d7283ada01572c56"
+        }
+      }
     }
   },
   "limitations": [
-    "The observed upstream model revisions are the current repository heads at evidence-recording time; local tree hashes are the binding identities for the tested artifacts.",
+    "The observed upstream model revisions are repository heads at evidence-recording time; 27B local tree hashes and Flash Next local source-manifest hashes bind the tested artifacts.",
     "The extended mean TTFT includes 8K, 32K, and 64K prompt prefill and must not be read as short-prompt interactive TTFT.",
-    "Generic MLX and MTPLX use different model artifacts; cross-lane results compare complete configurations, not engine code in isolation."
+    "Generic MLX and MTPLX use different model artifacts; cross-lane results compare complete configurations, not engine code in isolation.",
+    "MTPLX bench tune does not support the qwen4_exp Flash Next family, so Flash Next AR/D1-D5 rows were measured through the same local OpenAI route and matched prompt instead of the tune command.",
+    "MTPLX bench run was blocked before model load by a missing packaged Phase 0H exactness script; that infrastructure failure is not scored as a model failure."
   ]
 }

--- a/references/results/apple-m5-max-mtplx-20260830.json
+++ b/references/results/apple-m5-max-mtplx-20260830.json
@@ -1,0 +1,98 @@
+{
+  "schema": "turbofit.apple-mtplx-evidence/v1",
+  "recorded_at": "2026-08-30T21:20:00Z",
+  "tested_turbofit_commit": "98b45598785c4ca8efe5a5d5ea0835782f4ee007",
+  "classification": "measured",
+  "hardware": {
+    "chip": "Apple M5 Max",
+    "architecture": "arm64",
+    "system_memory_gib": 128,
+    "accelerator_memory_kind": "unified",
+    "os": "macOS 26.6.1"
+  },
+  "runtime": {
+    "engine": "MTPLX",
+    "version": "2.10.1",
+    "source_revision": "557e637a3aceba4cad7975582979e434aea7c092",
+    "profile": "turbo",
+    "context_length": 262144,
+    "route": "http://127.0.0.1:8091/v1 model auto"
+  },
+  "models": {
+    "optimized_speed": {
+      "repository": "Youssofal/Qwen3.8-27B-MTPLX-Optimized-Speed",
+      "upstream_revision_observed": "123db8bcc7101455b00d9aad36c0e760c6e7de02",
+      "local_tree_sha256": "d87ea9d73936766f6f7b58ab8b9e92a692e10a066fd3ffe4423e6b81a3b868e1",
+      "screening": {
+        "status": "pass",
+        "quality_pass_rate": 1.0,
+        "context_pass_rate": 1.0,
+        "effective_output_tokens_per_second": 41.975003,
+        "mean_ttft_ms": 671.839,
+        "peak_unified_memory_used_mib": 45562,
+        "raw_evidence_sha256": "sha256:5c534931521f8a3a5472eacc16271eb2cfa27e8b307b5eebfbf22812b48cdd50"
+      },
+      "extended": {
+        "status": "pass",
+        "passkey_context_words": [8192, 32768, 65536],
+        "quality_pass_rate": 1.0,
+        "context_pass_rate": 1.0,
+        "effective_output_tokens_per_second": 66.463529,
+        "mean_ttft_ms": 41392.4736,
+        "peak_unified_memory_used_mib": 65564,
+        "raw_evidence_sha256": "sha256:917af406232ad45fc3d2700b23b3eaa603f759db874cf6f1e708fa748977ea55"
+      },
+      "tune": {
+        "prompt_id": "long_warm_code_continuation",
+        "completion_tokens": 512,
+        "ar_end_to_end_tokens_per_second": 24.57799288235697,
+        "d1_end_to_end_tokens_per_second": 55.733720573030205,
+        "d2_end_to_end_tokens_per_second": 72.01606295772037,
+        "d3_end_to_end_tokens_per_second": 80.74638307794883,
+        "winner": "D3",
+        "quality_passed": true,
+        "raw_result_sha256": "sha256:04801ae2af634790077a5126e88a10b4deadc2073a6552ce3bf64c79aef26440"
+      }
+    },
+    "optimized_quality": {
+      "repository": "Youssofal/Qwen3.8-27B-MTPLX-Optimized-Quality",
+      "upstream_revision_observed": "09f71b39a75c416be3c974840b53f9fbe9aa1841",
+      "local_tree_sha256": "0502f4d65c20d53fd2cc193e723b7a0cfeb5ca7e1e944eb745798e34c4717a62",
+      "screening": {
+        "status": "pass",
+        "quality_pass_rate": 1.0,
+        "context_pass_rate": 1.0,
+        "effective_output_tokens_per_second": 38.435599,
+        "mean_ttft_ms": 688.519667,
+        "peak_unified_memory_used_mib": 53359,
+        "raw_evidence_sha256": "sha256:a6e70637dba248940a98b1cca53037afec6c55b2952eae072e2f8e041440d47e"
+      },
+      "extended": {
+        "status": "pass",
+        "passkey_context_words": [8192, 32768, 65536],
+        "quality_pass_rate": 1.0,
+        "context_pass_rate": 1.0,
+        "effective_output_tokens_per_second": 45.653045,
+        "mean_ttft_ms": 46198.6866,
+        "peak_unified_memory_used_mib": 73475,
+        "raw_evidence_sha256": "sha256:e49082bf83dadaa5682d56d5e3f7065bef23940b4e486d4208cabb0939c84ec1"
+      },
+      "tune": {
+        "prompt_id": "long_warm_code_continuation",
+        "completion_tokens": 512,
+        "ar_end_to_end_tokens_per_second": 16.929982640311664,
+        "d1_end_to_end_tokens_per_second": 41.670293345415814,
+        "d2_end_to_end_tokens_per_second": 55.835605511594125,
+        "d3_end_to_end_tokens_per_second": 57.64189944641718,
+        "winner": "D3",
+        "quality_passed": true,
+        "raw_result_sha256": "sha256:f08c2a6fd21f3f3c48b78e35a0772a22f7592ab517d2886d45240639789caa6c"
+      }
+    }
+  },
+  "limitations": [
+    "The observed upstream model revisions are the current repository heads at evidence-recording time; local tree hashes are the binding identities for the tested artifacts.",
+    "The extended mean TTFT includes 8K, 32K, and 64K prompt prefill and must not be read as short-prompt interactive TTFT.",
+    "Generic MLX and MTPLX use different model artifacts; cross-lane results compare complete configurations, not engine code in isolation."
+  ]
+}

--- a/schemas.py
+++ b/schemas.py
@@ -80,7 +80,7 @@ TURBOFIT_CONFIGURE = {
             },
             "install_native": {
                 "type": "boolean",
-                "description": "Install or verify the pinned native adaptive runtime.",
+                "description": "Explicitly install and activate the pinned native runtime. On supported Apple Silicon this downloads the selected MLX snapshot and starts loopback model and gateway processes.",
             },
             "install_freetoken": {
                 "type": "boolean",

--- a/scripts/install-mlx-runtime
+++ b/scripts/install-mlx-runtime
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Install or verify Turbofit's isolated pinned MLX/MLX-LM runtime."""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import platform
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Callable
+
+
+def _ensure_modern_python() -> None:
+    if sys.version_info >= (3, 10):
+        return
+    uv = shutil.which("uv")
+    if not uv:
+        raise RuntimeError("Python 3.10+ or uv is required to install the MLX runtime")
+    os.execv(uv, [uv, "run", "--python", "3.12", "python", __file__, *sys.argv[1:]])
+
+
+_ensure_modern_python()
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from turbofit_runtime.apple_mlx import MLX_LM_VERSION, MLX_VERSION  # noqa: E402
+
+
+def probe_versions(python: Path) -> dict[str, str]:
+    code = (
+        "import importlib.metadata as m, json; "
+        "print(json.dumps({'mlx': m.version('mlx'), 'mlx-lm': m.version('mlx-lm')}))"
+    )
+    output = subprocess.check_output([str(python), "-c", code], text=True, timeout=30)
+    return json.loads(output)
+
+
+def install(
+    *,
+    runtime_root: Path,
+    uv: str,
+    platform_name: str = sys.platform,
+    architecture: str = platform.machine(),
+    run: Callable[..., object] | None = None,
+    version_probe: Callable[[Path], dict[str, str]] = probe_versions,
+) -> dict[str, object]:
+    if platform_name != "darwin" or architecture.lower() not in {"arm64", "aarch64"}:
+        raise RuntimeError("MLX runtime requires Apple Silicon macOS")
+    execute = run or (lambda command, **kwargs: subprocess.run(command, check=True, **kwargs))
+    target = runtime_root.expanduser().resolve() / f"mlx-lm-{MLX_LM_VERSION}"
+    venv = target / ".venv"
+    python = venv / "bin" / "python"
+    if not python.is_file():
+        target.mkdir(parents=True, exist_ok=True)
+        execute([uv, "venv", "--python", "3.12", str(venv)])
+        execute([
+            uv,
+            "pip",
+            "install",
+            "--python",
+            str(python),
+            f"mlx=={MLX_VERSION}",
+            f"mlx-lm=={MLX_LM_VERSION}",
+        ])
+    versions = version_probe(python)
+    expected = {"mlx": MLX_VERSION, "mlx-lm": MLX_LM_VERSION}
+    if versions != expected:
+        raise RuntimeError(f"MLX runtime version mismatch: {versions} != {expected}")
+    return {
+        "schema": "turbofit.python-runtime-verification/v1",
+        "id": "mlx-lm",
+        "status": "verified",
+        "python": str(python),
+        "versions": versions,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--runtime-root",
+        type=Path,
+        default=Path("~/.local/share/turbofit/runtimes").expanduser(),
+    )
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+    uv = shutil.which("uv")
+    if not uv:
+        parser.error("uv is required to install the pinned MLX runtime")
+    result = install(runtime_root=args.runtime_root, uv=uv)
+    print(json.dumps(result, indent=2) if args.json else result["python"])
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/turbofit-gateway-runtime
+++ b/scripts/turbofit-gateway-runtime
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Manage Turbofit's owned loopback provider gateway."""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def _ensure_modern_python() -> None:
+    if sys.version_info >= (3, 10):
+        return
+    configured = os.environ.get("TURBOFIT_PYTHON")
+    candidates = ([Path(configured).expanduser()] if configured else []) + sorted(
+        Path("~/.local/share/turbofit/runtimes").expanduser().glob(
+            "mlx-lm-*/.venv/bin/python"
+        ),
+        reverse=True,
+    )
+    for candidate in candidates:
+        if candidate.is_file() and os.access(candidate, os.X_OK):
+            os.execv(str(candidate), [str(candidate), __file__, *sys.argv[1:]])
+    raise RuntimeError("Turbofit requires Python 3.10+; install the managed MLX runtime first")
+
+
+_ensure_modern_python()
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from turbofit_runtime.gateway_runtime import build_gateway_launch  # noqa: E402
+from turbofit_runtime.managed_engine import ManagedEngineRuntime  # noqa: E402
+
+
+def run_action(
+    action: str,
+    *,
+    runtime: ManagedEngineRuntime,
+    python: Path,
+    plugin_root: Path,
+    routes_path: Path,
+    port: int,
+    timeout_s: float,
+) -> dict[str, Any]:
+    if action == "start":
+        launch = build_gateway_launch(
+            python=python,
+            plugin_root=plugin_root,
+            routes_path=routes_path,
+            port=port,
+        )
+        resident = runtime.start_owned(launch, timeout_s=timeout_s)
+        return {
+            "ok": True,
+            "action": "start",
+            "pid": resident.pid,
+            "owned": resident.owned,
+        }
+    if action == "stop":
+        return {"ok": runtime.stop(), "action": "stop"}
+    if action == "status":
+        return {"action": "status", **runtime.inspect()}
+    raise ValueError(f"unsupported action: {action}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("action", choices=("start", "status", "stop"))
+    parser.add_argument("--python", type=Path, default=Path(sys.executable))
+    parser.add_argument("--plugin-root", type=Path, default=ROOT)
+    parser.add_argument(
+        "--routes",
+        type=Path,
+        default=Path(
+            os.getenv(
+                "TURBOFIT_RUNTIME_STATE",
+                "~/.local/state/turbofit/runtime-state.json",
+            )
+        ).expanduser(),
+    )
+    parser.add_argument(
+        "--state",
+        type=Path,
+        default=Path("~/.local/state/turbofit/gateway.json").expanduser(),
+    )
+    parser.add_argument("--port", type=int, default=8091)
+    parser.add_argument("--timeout", type=float, default=90.0)
+    args = parser.parse_args()
+    result = run_action(
+        args.action,
+        runtime=ManagedEngineRuntime(state_path=args.state),
+        python=args.python,
+        plugin_root=args.plugin_root,
+        routes_path=args.routes,
+        port=args.port,
+        timeout_s=args.timeout,
+    )
+    print(json.dumps(result, indent=2))
+    return 0 if result.get("ok") else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/turbofit-gateway.py
+++ b/scripts/turbofit-gateway.py
@@ -361,6 +361,22 @@ def check_port(port):
         return False
 
 
+def served_model_ids(port):
+    """Exact model IDs advertised by a local OpenAI-compatible backend."""
+    try:
+        with urlopen(f"http://127.0.0.1:{port}/v1/models", timeout=3) as response:
+            payload = json.load(response)
+    except Exception:
+        return set()
+    if not isinstance(payload, dict) or not isinstance(payload.get("data"), list):
+        return set()
+    return {
+        str(item.get("id"))
+        for item in payload["data"]
+        if isinstance(item, dict) and item.get("id")
+    }
+
+
 def runtime_override(role):
     """Resolve an explicitly activated evidence-backed runtime before catalog roles.
 
@@ -454,7 +470,8 @@ def _runtime_policy_route(state, role):
             port = int(route.get("port") or 0)
         except (TypeError, ValueError):
             return None
-        state_name = backend_state(port, alias)
+        model_id = str(route.get("model_id") or alias).strip()
+        state_name = backend_state(port, model_id)
         if state_name == "down":
             return None
         result = {
@@ -465,6 +482,9 @@ def _runtime_policy_route(state, role):
             "runtime_profile": state.get("active"),
             "runtime_rung": state.get("rung_id"),
         }
+        model_id = str(route.get("model_id") or "").strip()
+        if model_id:
+            result["model_id"] = model_id
         if route.get("context_length"):
             result["context_length"] = route["context_length"]
         if isinstance(route.get("request_policy"), dict):
@@ -496,7 +516,7 @@ def _runtime_policy_route(state, role):
     return None
 
 
-def backend_state(port, alias=None):
+def backend_state(port, expected_model_id=None):
     """Returns one of: 'ready', 'loading', 'down'.
 
     The port-SELF_PORT guard prevents a model registered on the gateway's own
@@ -508,6 +528,8 @@ def backend_state(port, alias=None):
     if not port_is_open(port):
         return "down"
     if check_port(port):
+        if expected_model_id and expected_model_id not in served_model_ids(port):
+            return "down"
         return "ready"
     return "loading"
 
@@ -771,14 +793,14 @@ def resolve_aux():
 
 # ─── Stall-while-loading ─────────────────────────────────────────────────────
 
-def stall_until_ready(port, deadline_ts, alias=None):
-    """Block (with periodic progress logs) until the local model is ready
+def stall_until_ready(port, deadline_ts, expected_model_id=None):
+    """Block (with periodic progress logs) until the exact local model is ready
     OR the deadline elapses. Returns the final state."""
     waited = 0.0
     poll = STALL_POLL_S
     last_log = 0.0
     while time.time() < deadline_ts:
-        state = backend_state(port, alias)
+        state = backend_state(port, expected_model_id)
         if state == "ready":
             if waited > 1.0:
                 log.info(f"Local backend :{port} ready after {waited:.1f}s stall")
@@ -794,7 +816,7 @@ def stall_until_ready(port, deadline_ts, alias=None):
         waited += poll
         # Gentle backoff capped at 5s
         poll = min(poll * 1.1, 5.0)
-    return backend_state(port, alias)  # final state at deadline
+    return backend_state(port, expected_model_id)  # final state at deadline
 
 
 # ─── HTTP handler ─────────────────────────────────────────────────────────────
@@ -906,7 +928,11 @@ class GatewayHandler(BaseHTTPRequestHandler):
             port = backend.get("port", 0)
             log.info(f"Stall-while-loading: :{port} (timeout {STALL_TIMEOUT_S:.0f}s)")
             stalled = True
-            new_state = stall_until_ready(port, deadline, backend.get("alias"))
+            new_state = stall_until_ready(
+                port,
+                deadline,
+                backend.get("model_id") or backend.get("alias"),
+            )
             if new_state == "ready":
                 backend["state"] = "ready"
             else:
@@ -1024,8 +1050,7 @@ class GatewayHandler(BaseHTTPRequestHandler):
                     payload["chat_template_kwargs"] = template_kwargs
                     payload.setdefault("reasoning_format", "none")
                 payload["model"] = (
-                    backend.get("model_id") if backend.get("is_api")
-                    else backend.get("alias")
+                    backend.get("model_id") or backend.get("alias")
                 ) or payload.get("model")
                 body = json.dumps(payload).encode()
             except Exception:

--- a/scripts/turbofit-mlx-runtime
+++ b/scripts/turbofit-mlx-runtime
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Manage Turbofit's owned generic Apple MLX runtime."""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def _ensure_modern_python() -> None:
+    if sys.version_info >= (3, 10):
+        return
+    configured = os.environ.get("TURBOFIT_PYTHON")
+    candidates = ([Path(configured).expanduser()] if configured else []) + sorted(
+        Path("~/.local/share/turbofit/runtimes").expanduser().glob(
+            "mlx-lm-*/.venv/bin/python"
+        ),
+        reverse=True,
+    )
+    for candidate in candidates:
+        if candidate.is_file() and os.access(candidate, os.X_OK):
+            os.execv(str(candidate), [str(candidate), __file__, *sys.argv[1:]])
+    raise RuntimeError("Turbofit requires Python 3.10+; install the managed MLX runtime first")
+
+
+_ensure_modern_python()
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from turbofit_runtime.apple_mlx import build_apple_mlx_launch  # noqa: E402
+from turbofit_runtime.managed_engine import (  # noqa: E402
+    ManagedEngineRuntime,
+    publish_engine_routes,
+)
+
+
+def _remove_own_routes(path: Path) -> None:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError, json.JSONDecodeError):
+        return
+    if payload.get("active") == "apple-mlx":
+        path.unlink(missing_ok=True)
+
+
+def run_action(
+    action: str,
+    *,
+    runtime: ManagedEngineRuntime,
+    model_root: Path,
+    runtime_root: Path,
+    routes_path: Path,
+    port: int,
+    timeout_s: float,
+) -> dict[str, Any]:
+    launch = build_apple_mlx_launch(
+        model_root=model_root,
+        runtime_root=runtime_root,
+        port=port,
+    )
+    if action == "start":
+        resident = runtime.start_owned(launch, timeout_s=timeout_s)
+        publish_engine_routes(routes_path, launch)
+        return {
+            "ok": True,
+            "action": "start",
+            "pid": resident.pid,
+            "owned": resident.owned,
+        }
+    if action == "stop":
+        stopped = runtime.stop()
+        if stopped:
+            _remove_own_routes(routes_path)
+        return {"ok": stopped, "action": "stop"}
+    if action == "status":
+        return {"action": "status", **runtime.inspect()}
+    raise ValueError(f"unsupported action: {action}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("action", choices=("start", "status", "stop"))
+    parser.add_argument(
+        "--model-root",
+        type=Path,
+        default=Path(os.getenv("TURBOFIT_MODEL_ROOT", "~/Models/storage/gguf")).expanduser(),
+    )
+    parser.add_argument(
+        "--runtime-root",
+        type=Path,
+        default=Path("~/.local/share/turbofit/runtimes").expanduser(),
+    )
+    parser.add_argument(
+        "--state",
+        type=Path,
+        default=Path("~/.local/state/turbofit/engines/mlx.json").expanduser(),
+    )
+    parser.add_argument(
+        "--routes",
+        type=Path,
+        default=Path(
+            os.getenv(
+                "TURBOFIT_RUNTIME_STATE",
+                "~/.local/state/turbofit/runtime-state.json",
+            )
+        ).expanduser(),
+    )
+    parser.add_argument("--port", type=int, default=18081)
+    parser.add_argument("--timeout", type=float, default=900.0)
+    args = parser.parse_args()
+    runtime = ManagedEngineRuntime(state_path=args.state)
+    result = run_action(
+        args.action,
+        runtime=runtime,
+        model_root=args.model_root,
+        runtime_root=args.runtime_root,
+        routes_path=args.routes,
+        port=args.port,
+        timeout_s=args.timeout,
+    )
+    print(json.dumps(result, indent=2))
+    return 0 if result.get("ok") else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/turbofit-mtplx-runtime
+++ b/scripts/turbofit-mtplx-runtime
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""Adopt or manage an MTPLX lane behind Turbofit's stable routes."""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import sys
+from pathlib import Path
+from typing import Any, Callable
+
+
+def _ensure_modern_python() -> None:
+    if sys.version_info >= (3, 10):
+        return
+    configured = os.environ.get("TURBOFIT_PYTHON")
+    candidates = ([Path(configured).expanduser()] if configured else []) + sorted(
+        Path("~/.local/share/turbofit/runtimes").expanduser().glob(
+            "mlx-lm-*/.venv/bin/python"
+        ),
+        reverse=True,
+    )
+    for candidate in candidates:
+        if candidate.is_file() and os.access(candidate, os.X_OK):
+            os.execv(str(candidate), [str(candidate), __file__, *sys.argv[1:]])
+    raise RuntimeError("Turbofit requires Python 3.10+; install the managed MLX runtime first")
+
+
+_ensure_modern_python()
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from turbofit_runtime.managed_engine import (  # noqa: E402
+    EngineLaunch,
+    ManagedEngineRuntime,
+    publish_engine_routes,
+)
+from turbofit_runtime.mtplx_engine import (  # noqa: E402
+    MTPLX_QUALITY_MODEL,
+    MTPLX_SPEED_MODEL,
+    build_mtplx_launch,
+    canonical_mtplx_alias,
+    discover_mtplx,
+    fetch_mtplx_metrics,
+    mtplx_telemetry,
+)
+
+
+def _external_launch(endpoint, executable: Path) -> EngineLaunch:
+    return EngineLaunch(
+        engine_id="mtplx",
+        model_id=canonical_mtplx_alias(endpoint.model_path),
+        model_path=Path(endpoint.model_path),
+        port=endpoint.port,
+        context_length=int(endpoint.health.get("context_window") or 262_144),
+        bind_host="127.0.0.1",
+        upstream_model_id=endpoint.model_id,
+        command=(
+            str(executable),
+            "serve",
+            "--model",
+            endpoint.model_path,
+            "--host",
+            "127.0.0.1",
+            "--port",
+            str(endpoint.port),
+        ),
+    )
+
+
+def _detach_routes(path: Path) -> None:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError, json.JSONDecodeError):
+        return
+    if payload.get("active") == "apple-mtplx":
+        path.unlink(missing_ok=True)
+
+
+def run_action(
+    action: str,
+    *,
+    runtime: ManagedEngineRuntime,
+    routes_path: Path,
+    discover: Callable[[], Any],
+    executable: Path,
+    model_path: Path | None,
+    model_repo: str | None,
+    model_id: str | None,
+    port: int,
+    timeout_s: float,
+) -> dict[str, Any]:
+    if action == "adopt":
+        endpoint = discover()
+        if endpoint is None:
+            raise RuntimeError("no healthy loopback MTPLX endpoint was discovered")
+        if endpoint.pid is None or endpoint.pid <= 0:
+            raise RuntimeError("the discovered MTPLX endpoint does not report a PID")
+        launch = _external_launch(endpoint, executable)
+        resident = runtime.adopt_external(launch, pid=endpoint.pid)
+        publish_engine_routes(routes_path, launch)
+        return {
+            "ok": True,
+            "action": "adopt",
+            "pid": resident.pid,
+            "owned": False,
+            "telemetry": mtplx_telemetry(endpoint.health, fetch_mtplx_metrics(endpoint)),
+        }
+    if action == "start":
+        if model_path is None or model_repo is None or model_id is None:
+            raise ValueError("start requires model path, repository, and model id")
+        launch = build_mtplx_launch(
+            executable=executable,
+            model_path=model_path,
+            model_repo=model_repo,
+            model_id=model_id,
+            port=port,
+        )
+        resident = runtime.start_owned(launch, timeout_s=timeout_s)
+        publish_engine_routes(routes_path, launch)
+        return {
+            "ok": True,
+            "action": "start",
+            "pid": resident.pid,
+            "owned": True,
+        }
+    if action in {"stop", "detach"}:
+        process_stopped = runtime.stop() if action == "stop" else False
+        _detach_routes(routes_path)
+        return {"ok": True, "action": "stop" if process_stopped else "detach", "process_stopped": process_stopped}
+    if action == "status":
+        endpoint = discover()
+        lifecycle = runtime.inspect()
+        managed = lifecycle.get("runtime") or {}
+        owned = bool(
+            endpoint is not None
+            and lifecycle.get("ok") is True
+            and managed.get("owned") is True
+            and managed.get("pid") == endpoint.pid
+            and managed.get("port") == endpoint.port
+        )
+        return {
+            "ok": endpoint is not None,
+            "action": "status",
+            "endpoint": None if endpoint is None else {
+                "host": endpoint.host,
+                "port": endpoint.port,
+                "model_id": endpoint.model_id,
+                "model_path": endpoint.model_path,
+                "pid": endpoint.pid,
+                "app_launch_id": endpoint.app_launch_id,
+                "owned_by_turbofit": owned,
+                "lifecycle_status": lifecycle.get("status"),
+                "telemetry": mtplx_telemetry(endpoint.health, fetch_mtplx_metrics(endpoint)),
+            },
+        }
+    raise ValueError(f"unsupported action: {action}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("action", choices=("adopt", "start", "status", "stop", "detach"))
+    parser.add_argument("--model-path", type=Path)
+    parser.add_argument("--model-repo", choices=(MTPLX_SPEED_MODEL, MTPLX_QUALITY_MODEL))
+    parser.add_argument("--model-id")
+    parser.add_argument("--port", type=int, default=18082)
+    parser.add_argument("--timeout", type=float, default=1200.0)
+    parser.add_argument(
+        "--routes",
+        type=Path,
+        default=Path("~/.local/state/turbofit/runtime-state.json").expanduser(),
+    )
+    parser.add_argument(
+        "--state",
+        type=Path,
+        default=Path("~/.local/state/turbofit/engines/mtplx.json").expanduser(),
+    )
+    parser.add_argument("--executable", type=Path)
+    args = parser.parse_args()
+    executable = args.executable or Path(shutil.which("mtplx") or "mtplx")
+    result = run_action(
+        args.action,
+        runtime=ManagedEngineRuntime(state_path=args.state),
+        routes_path=args.routes,
+        discover=discover_mtplx,
+        executable=executable,
+        model_path=args.model_path,
+        model_repo=args.model_repo,
+        model_id=args.model_id,
+        port=args.port,
+        timeout_s=args.timeout,
+    )
+    print(json.dumps(result, indent=2))
+    return 0 if result.get("ok") else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/turbofit-mtplx-runtime
+++ b/scripts/turbofit-mtplx-runtime
@@ -42,6 +42,8 @@ from turbofit_runtime.managed_engine import (  # noqa: E402
 from turbofit_runtime.mtplx_engine import (  # noqa: E402
     MTPLX_QUALITY_MODEL,
     MTPLX_SPEED_MODEL,
+    MTPLX_FLASH_BARE_SPEED,
+    MTPLX_FLASH_OPTIMIZED_SPEED,
     build_mtplx_launch,
     canonical_mtplx_alias,
     discover_mtplx,
@@ -165,7 +167,15 @@ def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("action", choices=("adopt", "start", "status", "stop", "detach"))
     parser.add_argument("--model-path", type=Path)
-    parser.add_argument("--model-repo", choices=(MTPLX_SPEED_MODEL, MTPLX_QUALITY_MODEL))
+    parser.add_argument(
+        "--model-repo",
+        choices=(
+            MTPLX_SPEED_MODEL,
+            MTPLX_QUALITY_MODEL,
+            MTPLX_FLASH_BARE_SPEED,
+            MTPLX_FLASH_OPTIMIZED_SPEED,
+        ),
+    )
     parser.add_argument("--model-id")
     parser.add_argument("--port", type=int, default=18082)
     parser.add_argument("--timeout", type=float, default=1200.0)

--- a/src/turbofit_runtime/allowed_lineup.py
+++ b/src/turbofit_runtime/allowed_lineup.py
@@ -35,6 +35,8 @@ ALLOWED_MAIN = (
     "qwen3-8-27b-uncensored-mlx-8bit",
     "qwen3-8-27b-mtplx-optimized-speed",
     "qwen3-8-27b-mtplx-optimized-quality",
+    "qwen3-8-flash-next-mtplx-bare-speed",
+    "qwen3-8-flash-next-mtplx-optimized-speed",
 )
 
 ALLOWED_AUX = (

--- a/src/turbofit_runtime/allowed_lineup.py
+++ b/src/turbofit_runtime/allowed_lineup.py
@@ -33,6 +33,8 @@ ALLOWED_MAIN = (
     "qwen3-8-27b-uncensored-mlx-4bit",
     "qwen3-8-27b-uncensored-mlx-6bit",
     "qwen3-8-27b-uncensored-mlx-8bit",
+    "qwen3-8-27b-mtplx-optimized-speed",
+    "qwen3-8-27b-mtplx-optimized-quality",
 )
 
 ALLOWED_AUX = (

--- a/src/turbofit_runtime/apple_mlx.py
+++ b/src/turbofit_runtime/apple_mlx.py
@@ -1,0 +1,77 @@
+"""Pinned generic MLX lane for Apple Silicon."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from .managed_engine import EngineLaunch
+
+
+MLX_VERSION = "0.32.2"
+MLX_LM_VERSION = "0.31.3"
+MODEL_REPO = "orcarouter/Qwen3.8-27B-Uncensored-MLX"
+MODEL_REVISION = "b4603df5fd2a51e7fed2560ee7090caa4e13e4b7"
+MODEL_FAMILY = "qwen3-8-27b-uncensored-mlx-8bit"
+MODEL_RELATIVE_PATH = Path("Qwen3.8-27B-Uncensored-MLX/8-bit")
+MODEL_CONTEXT = 262_144
+DEFAULT_RESPONSE_TOKENS = 32_768
+
+
+def load_python_runtime(path: str | Path, runtime_id: str) -> dict[str, Any]:
+    payload = json.loads(Path(path).read_text(encoding="utf-8"))
+    if payload.get("schema") != "turbofit.python-runtimes/v1":
+        raise ValueError("unsupported Python runtime manifest")
+    runtimes = payload.get("runtimes")
+    if not isinstance(runtimes, dict) or runtime_id not in runtimes:
+        raise KeyError(f"unknown Python runtime: {runtime_id}")
+    runtime = runtimes[runtime_id]
+    if not isinstance(runtime, dict):
+        raise ValueError(f"invalid Python runtime: {runtime_id}")
+    return runtime
+
+
+def build_apple_mlx_launch(
+    *,
+    model_root: str | Path,
+    runtime_root: str | Path,
+    port: int = 18081,
+) -> EngineLaunch:
+    model_path = Path(model_root).expanduser().resolve() / MODEL_RELATIVE_PATH
+    python = (
+        Path(runtime_root).expanduser().resolve()
+        / f"mlx-lm-{MLX_LM_VERSION}"
+        / ".venv"
+        / "bin"
+        / "python"
+    )
+    command = (
+        str(python),
+        "-m",
+        "mlx_lm",
+        "server",
+        "--model",
+        str(model_path),
+        "--host",
+        "127.0.0.1",
+        "--port",
+        str(port),
+        "--temp",
+        "1.0",
+        "--top-p",
+        "0.95",
+        "--top-k",
+        "20",
+        "--max-tokens",
+        str(DEFAULT_RESPONSE_TOKENS),
+    )
+    return EngineLaunch(
+        engine_id="mlx",
+        model_id=MODEL_FAMILY,
+        model_path=model_path,
+        port=port,
+        context_length=MODEL_CONTEXT,
+        bind_host="127.0.0.1",
+        upstream_model_id=str(model_path),
+        command=command,
+    )

--- a/src/turbofit_runtime/engine_check.py
+++ b/src/turbofit_runtime/engine_check.py
@@ -54,6 +54,18 @@ class EngineProbe(EngineCompatibility):
 _SPECS = (
     EngineSpec("llama.cpp", "llama.cpp", 8080, "Install Turbofit's pinned native llama.cpp runtime.", ("llama-server", "llama-server.exe"), ()),
     EngineSpec("mlx", "MLX", 8081, "Install mlx-lm on Apple Silicon macOS.", ("mlx_lm.server",), ("mlx_lm",)),
+    EngineSpec(
+        "mtplx",
+        "MTPLX",
+        8000,
+        "Install MTPLX 2.10.1 or newer on Apple Silicon macOS.",
+        ("mtplx",),
+        ("mtplx",),
+        "https://github.com/youssofal/MTPLX",
+        "v2.10.1",
+        "557e637a3aceba4cad7975582979e434aea7c092",
+        True,
+    ),
     EngineSpec("sglang", "SGLang", 30000, "Install SGLang on native Linux or inside WSL.", ("sglang",), ("sglang",)),
     EngineSpec("vllm", "vLLM", 8000, "Install vLLM on Linux/WSL or vLLM-Metal on Apple Silicon.", ("vllm",), ("vllm",)),
     EngineSpec("freetoken", "FreeToken", 1919, "Install freetoken[accel] on Linux x86_64 with CUDA 13.", ("ft",), ("freetoken",)),
@@ -193,9 +205,10 @@ def _compatibility(
     if spec.engine_id == "llama.cpp":
         compatible = os_name in {"linux", "windows", "darwin"}
         reason = "native cross-platform runtime" if compatible else reason
-    elif spec.engine_id == "mlx":
+    elif spec.engine_id in {"mlx", "mtplx"}:
         compatible = os_name == "darwin" and architecture in {"arm64", "aarch64"} and "metal" in backends
-        reason = "Apple Silicon Metal runtime" if compatible else "MLX requires Apple Silicon macOS with Metal"
+        label = "MTPLX" if spec.engine_id == "mtplx" else "MLX"
+        reason = f"Apple Silicon Metal {label} runtime" if compatible else f"{label} requires Apple Silicon macOS with Metal"
     elif spec.engine_id == "sglang":
         compatible = os_name == "linux" and bool(backends & {"cuda", "rocm"})
         reason = "Linux accelerator runtime" if compatible else "SGLang requires Linux/WSL with a supported accelerator"

--- a/src/turbofit_runtime/gateway_runtime.py
+++ b/src/turbofit_runtime/gateway_runtime.py
@@ -1,0 +1,37 @@
+"""Owned loopback launch contract for the Turbofit provider gateway."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from .managed_engine import EngineLaunch
+
+
+def build_gateway_launch(
+    *,
+    python: str | Path,
+    plugin_root: str | Path,
+    routes_path: str | Path,
+    port: int = 8091,
+) -> EngineLaunch:
+    root = Path(plugin_root).resolve()
+    script = root / "scripts" / "turbofit-gateway.py"
+    routes = Path(routes_path).expanduser().resolve()
+    command = (
+        "/usr/bin/env",
+        "TURBOFIT_GATEWAY_HOST=127.0.0.1",
+        f"TURBOFIT_GATEWAY_PORT={port}",
+        f"TURBOFIT_RUNTIME_STATE={routes}",
+        str(Path(python).expanduser().resolve()),
+        str(script),
+    )
+    return EngineLaunch(
+        engine_id="turbofit-gateway",
+        model_id="auto",
+        model_path=root,
+        port=port,
+        context_length=262_144,
+        bind_host="127.0.0.1",
+        upstream_model_id="auto",
+        command=command,
+        required_model_files=(),
+    )

--- a/src/turbofit_runtime/managed_engine.py
+++ b/src/turbofit_runtime/managed_engine.py
@@ -1,0 +1,402 @@
+"""Ownership-safe lifecycle for loopback OpenAI-compatible model engines."""
+from __future__ import annotations
+
+import ipaddress
+import json
+import os
+import shlex
+import signal
+import subprocess
+import time
+import urllib.request
+from contextlib import contextmanager
+from dataclasses import asdict, dataclass, replace
+from pathlib import Path
+from typing import Any, Callable, Mapping
+
+from .routes import publish_route_state
+
+
+@dataclass(frozen=True)
+class EngineLaunch:
+    engine_id: str
+    model_id: str
+    model_path: Path
+    port: int
+    context_length: int
+    bind_host: str
+    upstream_model_id: str
+    command: tuple[str, ...]
+    required_model_files: tuple[str, ...] = ("config.json",)
+
+    def __post_init__(self) -> None:
+        if not self.engine_id or not self.model_id or not self.upstream_model_id or not self.command:
+            raise ValueError("engine, model, and command must be non-empty")
+        if isinstance(self.port, bool) or not 1 <= self.port <= 65535:
+            raise ValueError("engine port must be in 1..65535")
+        if isinstance(self.context_length, bool) or self.context_length <= 0:
+            raise ValueError("context_length must be positive")
+        try:
+            address = ipaddress.ip_address(self.bind_host)
+        except ValueError as exc:
+            raise ValueError("managed engine bind host must be an IP address") from exc
+        if not address.is_loopback:
+            raise ValueError("managed engines must bind to loopback")
+
+
+@dataclass(frozen=True)
+class EngineResident:
+    engine_id: str
+    model_id: str
+    model_path: str
+    port: int
+    context_length: int
+    bind_host: str
+    upstream_model_id: str
+    pid: int
+    command: tuple[str, ...]
+    owned: bool
+    status: str = "ready"
+
+
+class ManagedEngineRuntime:
+    """Start or adopt an engine while signalling only a verified owned PID."""
+
+    def __init__(
+        self,
+        *,
+        state_path: str | Path,
+        process_factory: Callable[..., Any] = subprocess.Popen,
+        command_line: Callable[[int], str] | None = None,
+        listener_pids: Callable[[int], tuple[int, ...]] | None = None,
+        signal_process: Callable[[int, int], None] = os.kill,
+        json_get: Callable[[str, float], Any] | None = None,
+        sleep: Callable[[float], None] = time.sleep,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self.state_path = Path(state_path)
+        self.lock_path = self.state_path.with_suffix(".lock")
+        self.process_factory = process_factory
+        self.command_line = command_line or self._command_line
+        self.listener_pids = listener_pids or self._listener_pids
+        self.signal_process = signal_process
+        self.json_get = json_get or self._json_get
+        self.sleep = sleep
+        self.clock = clock
+        self._resident: EngineResident | None = None
+        self._process: Any | None = None
+
+    @contextmanager
+    def _lifecycle_lock(self):
+        self.lock_path.parent.mkdir(parents=True, exist_ok=True)
+        with self.lock_path.open("a+") as handle:
+            if os.name == "nt":
+                import msvcrt
+
+                handle.seek(0)
+                msvcrt.locking(handle.fileno(), msvcrt.LK_LOCK, 1)
+                try:
+                    yield
+                finally:
+                    handle.seek(0)
+                    msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+            else:
+                import fcntl
+
+                fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+                try:
+                    yield
+                finally:
+                    fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
+    @staticmethod
+    def _command_line(pid: int) -> str:
+        try:
+            result = subprocess.run(
+                ["ps", "-p", str(pid), "-o", "command="],
+                capture_output=True,
+                text=True,
+                timeout=3,
+                check=False,
+            )
+        except (OSError, subprocess.SubprocessError):
+            return ""
+        return result.stdout.strip() if result.returncode == 0 else ""
+
+    @staticmethod
+    def _listener_pids(port: int) -> tuple[int, ...]:
+        try:
+            result = subprocess.run(
+                ["lsof", "-nP", f"-iTCP:{port}", "-sTCP:LISTEN", "-t"],
+                capture_output=True,
+                text=True,
+                timeout=3,
+                check=False,
+            )
+        except (OSError, subprocess.SubprocessError):
+            return ()
+        if result.returncode not in {0, 1}:
+            return ()
+        return tuple(
+            int(line)
+            for line in result.stdout.splitlines()
+            if line.strip().isdigit()
+        )
+
+    @staticmethod
+    def _json_get(url: str, timeout: float) -> Any:
+        with urllib.request.urlopen(url, timeout=timeout) as response:
+            return json.loads(response.read().decode("utf-8"))
+
+    @staticmethod
+    def _resident_for(spec: EngineLaunch, *, pid: int, owned: bool) -> EngineResident:
+        return EngineResident(
+            engine_id=spec.engine_id,
+            model_id=spec.model_id,
+            model_path=str(spec.model_path),
+            port=spec.port,
+            context_length=spec.context_length,
+            bind_host=spec.bind_host,
+            upstream_model_id=spec.upstream_model_id,
+            pid=pid,
+            command=spec.command,
+            owned=owned,
+        )
+
+    def _ready(self, spec: EngineLaunch) -> bool:
+        base = f"http://127.0.0.1:{spec.port}"
+        try:
+            models = self.json_get(base + "/v1/models", 2.0)
+        except (OSError, ValueError):
+            return False
+        if not isinstance(models, Mapping):
+            return False
+        ids = {
+            str(item.get("id"))
+            for item in (models.get("data") or [])
+            if isinstance(item, dict)
+        }
+        if spec.upstream_model_id not in ids:
+            return False
+        try:
+            health = self.json_get(base + "/health", 2.0)
+        except (OSError, ValueError):
+            return True
+        if not isinstance(health, dict):
+            return False
+        return bool(
+            health.get("ok") is True
+            or health.get("status") in {"ok", "ready", "healthy", "loaded"}
+        )
+
+    def _write_owned(self, resident: EngineResident) -> None:
+        payload = {
+            "schema": "turbofit.managed-engine/v1",
+            **asdict(resident),
+            "command": list(resident.command),
+        }
+        publish_route_state(self.state_path, payload)
+
+    def start_owned(self, spec: EngineLaunch, *, timeout_s: float = 900.0) -> EngineResident:
+        with self._lifecycle_lock():
+            return self._start_owned(spec, timeout_s=timeout_s)
+
+    def _start_owned(self, spec: EngineLaunch, *, timeout_s: float) -> EngineResident:
+        executable = Path(spec.command[0])
+        if not executable.is_file() or not os.access(executable, os.X_OK):
+            raise RuntimeError(f"engine executable is unavailable: {executable}")
+        if not spec.model_path.is_dir() or any(
+            not (spec.model_path / relative).is_file()
+            for relative in spec.required_model_files
+        ):
+            raise RuntimeError(f"model snapshot is incomplete: {spec.model_path}")
+        occupants = self.listener_pids(spec.port)
+        if occupants:
+            raise RuntimeError(
+                f"engine port {spec.port} is already occupied by PID(s) "
+                + ",".join(str(pid) for pid in occupants)
+            )
+        log_path = self.state_path.with_suffix(".log")
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        log = log_path.open("a", encoding="utf-8")
+        process = self.process_factory(
+            list(spec.command),
+            stdout=log,
+            stderr=subprocess.STDOUT,
+            text=True,
+            start_new_session=True,
+        )
+        log.close()
+        self._process = process
+        resident = replace(
+            self._resident_for(spec, pid=int(process.pid), owned=True),
+            status="launching",
+        )
+        self._write_owned(resident)
+        deadline = self.clock() + timeout_s
+        while True:
+            if process.poll() is not None:
+                break
+            if self._ready(spec) and resident.pid in self.listener_pids(spec.port):
+                actual = self.command_line(resident.pid)
+                if actual:
+                    try:
+                        resident = replace(resident, command=tuple(shlex.split(actual)))
+                    except ValueError:
+                        pass
+                resident = replace(resident, status="ready")
+                self._resident = resident
+                self._write_owned(resident)
+                return resident
+            if self.clock() >= deadline:
+                break
+            self.sleep(min(0.5, max(0.0, deadline - self.clock())))
+        if process.poll() is None:
+            process.terminate()
+        cleanup_deadline = time.monotonic() + 30.0
+        while process.poll() is None and time.monotonic() < cleanup_deadline:
+            self.sleep(0.2)
+        if process.poll() is None:
+            resident = replace(resident, status="cleanup-timeout")
+            self._resident = resident
+            self._write_owned(resident)
+        else:
+            self._resident = None
+            self.state_path.unlink(missing_ok=True)
+        self._process = None
+        raise RuntimeError(f"{spec.engine_id} did not become ready with model {spec.model_id}")
+
+    def adopt_external(self, spec: EngineLaunch, *, pid: int) -> EngineResident:
+        if pid <= 0 or not self._ready(spec):
+            raise RuntimeError(f"external {spec.engine_id} endpoint is not ready")
+        if pid not in self.listener_pids(spec.port):
+            raise RuntimeError(
+                f"external {spec.engine_id} PID {pid} does not own port {spec.port}"
+            )
+        resident = self._resident_for(spec, pid=pid, owned=False)
+        self._resident = resident
+        return resident
+
+    @staticmethod
+    def _command_matches(expected: tuple[str, ...], actual: str) -> bool:
+        if not actual:
+            return False
+        try:
+            observed = shlex.split(actual)
+        except ValueError:
+            return False
+        return tuple(observed) == expected
+
+    def _load_record(self) -> EngineResident | None:
+        if self._resident is not None:
+            return self._resident
+        try:
+            raw = json.loads(self.state_path.read_text(encoding="utf-8"))
+            if raw.get("schema") != "turbofit.managed-engine/v1":
+                return None
+            return EngineResident(
+                engine_id=str(raw["engine_id"]),
+                model_id=str(raw["model_id"]),
+                model_path=str(raw["model_path"]),
+                port=int(raw["port"]),
+                context_length=int(raw["context_length"]),
+                bind_host=str(raw["bind_host"]),
+                upstream_model_id=str(raw["upstream_model_id"]),
+                pid=int(raw["pid"]),
+                command=tuple(str(item) for item in raw["command"]),
+                owned=raw["owned"] is True,
+                status=str(raw.get("status") or "ready"),
+            )
+        except (OSError, ValueError, TypeError, KeyError, json.JSONDecodeError):
+            return None
+
+    def inspect(self) -> dict[str, Any]:
+        resident = self._load_record()
+        if resident is None:
+            return {"ok": False, "status": "down", "runtime": None}
+        payload = {
+            "engine_id": resident.engine_id,
+            "model_id": resident.model_id,
+            "pid": resident.pid,
+            "port": resident.port,
+            "owned": resident.owned,
+        }
+        if resident.owned and not self._command_matches(
+            resident.command, self.command_line(resident.pid)
+        ):
+            return {"ok": False, "status": "stale", "runtime": payload}
+        if resident.pid not in self.listener_pids(resident.port):
+            return {"ok": False, "status": "stale", "runtime": payload}
+        spec = EngineLaunch(
+            engine_id=resident.engine_id,
+            model_id=resident.model_id,
+            model_path=Path(resident.model_path),
+            port=resident.port,
+            context_length=resident.context_length,
+            bind_host=resident.bind_host,
+            upstream_model_id=resident.upstream_model_id,
+            command=resident.command,
+            required_model_files=(),
+        )
+        if not self._ready(spec):
+            return {"ok": False, "status": "loading", "runtime": payload}
+        return {"ok": True, "status": "ready", "runtime": payload}
+
+    def stop(self, *, timeout_s: float = 30.0) -> bool:
+        with self._lifecycle_lock():
+            return self._stop(timeout_s=timeout_s)
+
+    def _stop(self, *, timeout_s: float) -> bool:
+        resident = self._load_record()
+        if resident is None or not resident.owned:
+            self._resident = None
+            self.state_path.unlink(missing_ok=True)
+            return True
+        actual = self.command_line(resident.pid)
+        if not self._command_matches(resident.command, actual):
+            resident = replace(resident, status="command-mismatch")
+            self._resident = resident
+            self._write_owned(resident)
+            return False
+        if self._process is not None:
+            self._process.terminate()
+        else:
+            self.signal_process(resident.pid, signal.SIGTERM)
+        deadline = self.clock() + max(0.0, timeout_s)
+        while self.clock() < deadline:
+            actual = self.command_line(resident.pid)
+            if not self._command_matches(resident.command, actual):
+                self._resident = None
+                self._process = None
+                self.state_path.unlink(missing_ok=True)
+                return True
+            self.sleep(0.2)
+        resident = replace(resident, status="stop-timeout")
+        self._resident = resident
+        self._write_owned(resident)
+        return False
+
+
+def publish_engine_routes(path: str | Path, spec: EngineLaunch) -> None:
+    publish_route_state(
+        path,
+        {
+            "schema": "turbofit.runtime-routes/v1",
+            "active": f"apple-{spec.engine_id}",
+            "rung_id": f"{spec.engine_id}-{spec.model_id}",
+            "routes": {
+                "main": {
+                    "kind": "local",
+                    "alias": spec.model_id,
+                    "model_id": spec.upstream_model_id,
+                    "port": spec.port,
+                    "context_length": spec.context_length,
+                    "engine": spec.engine_id,
+                },
+                "aux": {
+                    "kind": "shared-main",
+                    "context_length": spec.context_length,
+                },
+            },
+        },
+    )

--- a/src/turbofit_runtime/mtplx_engine.py
+++ b/src/turbofit_runtime/mtplx_engine.py
@@ -12,6 +12,8 @@ from .managed_engine import EngineLaunch
 
 MTPLX_SPEED_MODEL = "Youssofal/Qwen3.8-27B-MTPLX-Optimized-Speed"
 MTPLX_QUALITY_MODEL = "Youssofal/Qwen3.8-27B-MTPLX-Optimized-Quality"
+MTPLX_FLASH_BARE_SPEED = "Youssofal/Qwen3.8-Flash-Next-MTPLX-Bare-Speed"
+MTPLX_FLASH_OPTIMIZED_SPEED = "Youssofal/Qwen3.8-Flash-Next-MTPLX-Optimized-Speed"
 MTPLX_MIN_VERSION = "2.10.1"
 DEFAULT_APP_SETTINGS = Path("~/Library/Application Support/MTPLX/settings.json")
 DEFAULT_PORTS = (18082, 8000, 18083, 18084, 18085)
@@ -23,6 +25,10 @@ def canonical_mtplx_alias(model_path: str | Path) -> str:
         return "qwen3-8-27b-mtplx-optimized-speed"
     if "qwen3.8-27b-mtplx-optimized-quality" in name:
         return "qwen3-8-27b-mtplx-optimized-quality"
+    if "qwen3.8-flash-next-mtplx-bare-speed" in name:
+        return "qwen3-8-flash-next-mtplx-bare-speed"
+    if "qwen3.8-flash-next-mtplx-optimized-speed" in name:
+        return "qwen3-8-flash-next-mtplx-optimized-speed"
     raise ValueError(f"unsupported MTPLX model path: {model_path}")
 
 
@@ -96,7 +102,12 @@ def build_mtplx_launch(
     model_id: str,
     port: int,
 ) -> EngineLaunch:
-    if model_repo not in {MTPLX_SPEED_MODEL, MTPLX_QUALITY_MODEL}:
+    if model_repo not in {
+        MTPLX_SPEED_MODEL,
+        MTPLX_QUALITY_MODEL,
+        MTPLX_FLASH_BARE_SPEED,
+        MTPLX_FLASH_OPTIMIZED_SPEED,
+    }:
         raise ValueError(f"unsupported MTPLX model: {model_repo}")
     path = Path(model_path).expanduser().resolve()
     command = (

--- a/src/turbofit_runtime/mtplx_engine.py
+++ b/src/turbofit_runtime/mtplx_engine.py
@@ -1,0 +1,173 @@
+"""MTPLX discovery, launch contracts, and telemetry normalization."""
+from __future__ import annotations
+
+import json
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Mapping
+
+from .managed_engine import EngineLaunch
+
+
+MTPLX_SPEED_MODEL = "Youssofal/Qwen3.8-27B-MTPLX-Optimized-Speed"
+MTPLX_QUALITY_MODEL = "Youssofal/Qwen3.8-27B-MTPLX-Optimized-Quality"
+MTPLX_MIN_VERSION = "2.10.1"
+DEFAULT_APP_SETTINGS = Path("~/Library/Application Support/MTPLX/settings.json")
+DEFAULT_PORTS = (18082, 8000, 18083, 18084, 18085)
+
+
+def canonical_mtplx_alias(model_path: str | Path) -> str:
+    name = Path(model_path).name.lower()
+    if "qwen3.8-27b-mtplx-optimized-speed" in name:
+        return "qwen3-8-27b-mtplx-optimized-speed"
+    if "qwen3.8-27b-mtplx-optimized-quality" in name:
+        return "qwen3-8-27b-mtplx-optimized-quality"
+    raise ValueError(f"unsupported MTPLX model path: {model_path}")
+
+
+@dataclass(frozen=True)
+class MtplxEndpoint:
+    host: str
+    port: int
+    model_id: str
+    model_path: str
+    pid: int | None
+    app_launch_id: str | None
+    health: Mapping[str, Any]
+    owned_by_turbofit: bool = False
+
+
+def _json_get(url: str, timeout: float) -> Any:
+    with urllib.request.urlopen(url, timeout=timeout) as response:
+        return json.loads(response.read().decode("utf-8"))
+
+
+def _settings_port(path: Path) -> int | None:
+    try:
+        payload = json.loads(path.expanduser().read_text(encoding="utf-8"))
+        port = int(payload.get("port") or 0)
+    except (OSError, ValueError, TypeError, json.JSONDecodeError):
+        return None
+    return port if 1 <= port <= 65535 else None
+
+
+def discover_mtplx(
+    *,
+    settings_path: str | Path = DEFAULT_APP_SETTINGS,
+    ports: tuple[int, ...] = DEFAULT_PORTS,
+    json_get: Callable[[str, float], Any] = _json_get,
+) -> MtplxEndpoint | None:
+    app_port = _settings_port(Path(settings_path))
+    ordered = ((app_port,) if app_port else ()) + tuple(
+        port for port in ports if port != app_port
+    )
+    for port in ordered:
+        try:
+            health = json_get(f"http://127.0.0.1:{port}/health", 1.5)
+        except (OSError, ValueError):
+            continue
+        if not isinstance(health, Mapping) or health.get("ok") is not True:
+            continue
+        model_id = str(health.get("model") or "").strip()
+        model_path = str(health.get("model_path") or "").strip()
+        if not model_id or not model_path:
+            continue
+        startup = health.get("startup")
+        startup = startup if isinstance(startup, Mapping) else {}
+        pid = startup.get("pid")
+        return MtplxEndpoint(
+            host="127.0.0.1",
+            port=port,
+            model_id=model_id,
+            model_path=model_path,
+            pid=int(pid) if isinstance(pid, int) and pid > 0 else None,
+            app_launch_id=str(startup.get("launch_id") or "") or None,
+            health=health,
+        )
+    return None
+
+
+def build_mtplx_launch(
+    *,
+    executable: str | Path,
+    model_path: str | Path,
+    model_repo: str,
+    model_id: str,
+    port: int,
+) -> EngineLaunch:
+    if model_repo not in {MTPLX_SPEED_MODEL, MTPLX_QUALITY_MODEL}:
+        raise ValueError(f"unsupported MTPLX model: {model_repo}")
+    path = Path(model_path).expanduser().resolve()
+    command = (
+        str(Path(executable).expanduser().resolve()),
+        "serve",
+        "--model",
+        str(path),
+        "--profile",
+        "turbo",
+        "--host",
+        "127.0.0.1",
+        "--port",
+        str(port),
+        "--no-auth",
+        "--model-id",
+        model_id,
+        "--generation-mode",
+        "mtp",
+        "--fan-mode",
+        "default",
+        "--no-stats-footer",
+    )
+    return EngineLaunch(
+        engine_id="mtplx",
+        model_id=model_id,
+        model_path=path,
+        port=port,
+        context_length=262_144,
+        bind_host="127.0.0.1",
+        upstream_model_id=model_id,
+        command=command,
+    )
+
+
+def fetch_mtplx_metrics(
+    endpoint: MtplxEndpoint,
+    *,
+    json_get: Callable[[str, float], Any] = _json_get,
+) -> Mapping[str, Any]:
+    try:
+        payload = json_get(f"http://{endpoint.host}:{endpoint.port}/metrics", 2.0)
+    except (OSError, ValueError):
+        return {}
+    return payload if isinstance(payload, Mapping) else {}
+
+
+def mtplx_telemetry(
+    health: Mapping[str, Any],
+    metrics_payload: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    scheduler = health.get("scheduler")
+    scheduler = scheduler if isinstance(scheduler, Mapping) else {}
+    memory = health.get("memory_plan")
+    memory = memory if isinstance(memory, Mapping) else {}
+    payload = metrics_payload if isinstance(metrics_payload, Mapping) else {}
+    metrics = payload.get("latest")
+    metrics = metrics if isinstance(metrics, Mapping) else {}
+    acceptance = metrics.get("acceptance_rate")
+    if acceptance is None:
+        acceptance = metrics.get("mtp_acceptance_rate")
+    return {
+        "engine": "mtplx",
+        "model": health.get("model"),
+        "generation_mode": health.get("generation_mode"),
+        "depth": metrics.get("request_effective_mtp_depth", health.get("depth")),
+        "scheduler_mode": scheduler.get("mode"),
+        "active_requests": scheduler.get("active_requests"),
+        "context_length": memory.get("context_window_resolved"),
+        "model_weights_bytes": memory.get("model_weights_bytes"),
+        "peak_memory_bytes": metrics.get("peak_memory_bytes"),
+        "decode_tokens_per_second": metrics.get("decode_tok_s"),
+        "request_tokens_per_second": metrics.get("request_tok_s"),
+        "acceptance_rate": acceptance,
+    }

--- a/src/turbofit_runtime/mtplx_engine.py
+++ b/src/turbofit_runtime/mtplx_engine.py
@@ -14,6 +14,12 @@ MTPLX_SPEED_MODEL = "Youssofal/Qwen3.8-27B-MTPLX-Optimized-Speed"
 MTPLX_QUALITY_MODEL = "Youssofal/Qwen3.8-27B-MTPLX-Optimized-Quality"
 MTPLX_FLASH_BARE_SPEED = "Youssofal/Qwen3.8-Flash-Next-MTPLX-Bare-Speed"
 MTPLX_FLASH_OPTIMIZED_SPEED = "Youssofal/Qwen3.8-Flash-Next-MTPLX-Optimized-Speed"
+MTPLX_MEASURED_DEPTHS = {
+    MTPLX_SPEED_MODEL: 3,
+    MTPLX_QUALITY_MODEL: 3,
+    MTPLX_FLASH_BARE_SPEED: 2,
+    MTPLX_FLASH_OPTIMIZED_SPEED: 3,
+}
 MTPLX_MIN_VERSION = "2.10.1"
 DEFAULT_APP_SETTINGS = Path("~/Library/Application Support/MTPLX/settings.json")
 DEFAULT_PORTS = (18082, 8000, 18083, 18084, 18085)
@@ -109,6 +115,7 @@ def build_mtplx_launch(
         MTPLX_FLASH_OPTIMIZED_SPEED,
     }:
         raise ValueError(f"unsupported MTPLX model: {model_repo}")
+    depth = MTPLX_MEASURED_DEPTHS[model_repo]
     path = Path(model_path).expanduser().resolve()
     command = (
         str(Path(executable).expanduser().resolve()),
@@ -121,6 +128,8 @@ def build_mtplx_launch(
         "127.0.0.1",
         "--port",
         str(port),
+        "--depth",
+        str(depth),
         "--no-auth",
         "--model-id",
         model_id,

--- a/tests/test_allowed_lineup.py
+++ b/tests/test_allowed_lineup.py
@@ -64,6 +64,8 @@ def test_shared_total_memory_is_not_treated_as_vram() -> None:
 def test_apple_uses_orcarouter_mlx_not_two_bit() -> None:
     assert is_allowed_main("qwen3-8-27b-mtplx-optimized-speed")
     assert is_allowed_main("qwen3-8-27b-mtplx-optimized-quality")
+    assert is_allowed_main("qwen3-8-flash-next-mtplx-bare-speed")
+    assert is_allowed_main("qwen3-8-flash-next-mtplx-optimized-speed")
     assert apple_mlx_main(unified_ram_gb=16) == "ornith-1-5-35a3b"
     assert apple_mlx_main(unified_ram_gb=24) == "qwen3-8-27b-uncensored-mlx-4bit"
     assert apple_mlx_main(unified_ram_gb=32) == "qwen3-8-27b-uncensored-mlx-6bit"

--- a/tests/test_allowed_lineup.py
+++ b/tests/test_allowed_lineup.py
@@ -62,6 +62,8 @@ def test_shared_total_memory_is_not_treated_as_vram() -> None:
 
 
 def test_apple_uses_orcarouter_mlx_not_two_bit() -> None:
+    assert is_allowed_main("qwen3-8-27b-mtplx-optimized-speed")
+    assert is_allowed_main("qwen3-8-27b-mtplx-optimized-quality")
     assert apple_mlx_main(unified_ram_gb=16) == "ornith-1-5-35a3b"
     assert apple_mlx_main(unified_ram_gb=24) == "qwen3-8-27b-uncensored-mlx-4bit"
     assert apple_mlx_main(unified_ram_gb=32) == "qwen3-8-27b-uncensored-mlx-6bit"

--- a/tests/test_apple_mlx_runtime.py
+++ b/tests/test_apple_mlx_runtime.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from turbofit_runtime.apple_mlx import (
+    MLX_LM_VERSION,
+    MLX_VERSION,
+    MODEL_FAMILY,
+    MODEL_REVISION,
+    MODEL_REPO,
+    build_apple_mlx_launch,
+    load_python_runtime,
+)
+
+
+ROOT = Path(__file__).parents[1]
+
+
+def test_apple_mlx_runtime_and_model_are_immutably_pinned(tmp_path: Path) -> None:
+    runtime = load_python_runtime(ROOT / "references/python-runtimes.json", "mlx-lm")
+
+    assert runtime["packages"] == {
+        "mlx": f"mlx=={MLX_VERSION}",
+        "mlx-lm": f"mlx-lm=={MLX_LM_VERSION}",
+    }
+    assert MODEL_REPO == "orcarouter/Qwen3.8-27B-Uncensored-MLX"
+    assert MODEL_REVISION == "b4603df5fd2a51e7fed2560ee7090caa4e13e4b7"
+    assert MODEL_FAMILY == "qwen3-8-27b-uncensored-mlx-8bit"
+
+
+def test_build_apple_mlx_launch_uses_loopback_and_real_upstream_model_id(
+    tmp_path: Path,
+) -> None:
+    runtime_root = tmp_path / "runtimes"
+    python = runtime_root / f"mlx-lm-{MLX_LM_VERSION}" / ".venv/bin/python"
+    python.parent.mkdir(parents=True)
+    python.write_text("python")
+    python.chmod(0o755)
+    model_root = tmp_path / "models"
+    model = model_root / "Qwen3.8-27B-Uncensored-MLX/8-bit"
+    model.mkdir(parents=True)
+    (model / "config.json").write_text("{}")
+
+    launch = build_apple_mlx_launch(
+        model_root=model_root,
+        runtime_root=runtime_root,
+        port=18081,
+    )
+
+    assert launch.engine_id == "mlx"
+    assert launch.model_id == MODEL_FAMILY
+    assert launch.upstream_model_id == str(model)
+    assert launch.context_length == 262_144
+    assert launch.command == (
+        str(python),
+        "-m",
+        "mlx_lm",
+        "server",
+        "--model",
+        str(model),
+        "--host",
+        "127.0.0.1",
+        "--port",
+        "18081",
+        "--temp",
+        "1.0",
+        "--top-p",
+        "0.95",
+        "--top-k",
+        "20",
+        "--max-tokens",
+        "32768",
+    )

--- a/tests/test_artifact_manifest.py
+++ b/tests/test_artifact_manifest.py
@@ -26,11 +26,29 @@ def test_artifact_manifest_covers_every_executable_matrix_file() -> None:
     model_root = Path.home() / "Models/storage/gguf"
     expected_destinations = {str(Path(path).relative_to(model_root)) for path in expected}
     actual = {item["destination"] for item in payload["artifacts"]}
+    mlx_destinations = {
+        item["destination"]
+        for item in payload["artifacts"]
+        if "qwen3-8-27b-uncensored-mlx-8bit" in item.get("families", [])
+    }
+    known_non_matrix_destinations = {
+        item["destination"]
+        for item in payload["artifacts"]
+        if item.get("repo_id") == "unsloth/MiniMax-M3-GGUF"
+    }
 
     assert payload["schema"] == "turbofit.artifact-manifest/v1"
     assert expected_destinations <= actual
-    assert len(actual) == 36
-    assert all(len(item["sha256"]) == 64 for item in payload["artifacts"])
+    assert actual == expected_destinations | known_non_matrix_destinations | mlx_destinations
+    assert mlx_destinations
+    assert all(
+        len(item["sha256"]) == 64
+        or (
+            item["sha256"].startswith("snapshot:")
+            and len(item["sha256"].removeprefix("snapshot:")) == 40
+        )
+        for item in payload["artifacts"]
+    )
     assert all(len(item["revision"]) == 40 for item in payload["artifacts"])
     assert all(item["size_bytes"] > 0 for item in payload["artifacts"])
 

--- a/tests/test_download_artifacts.py
+++ b/tests/test_download_artifacts.py
@@ -33,6 +33,42 @@ def test_selected_artifacts_filters_complete_family() -> None:
     }
 
 
+def test_apple_mlx_8bit_family_is_a_complete_pinned_snapshot() -> None:
+    module = load_script()
+    payload = __import__("json").loads((ROOT / "references/artifact-manifest.json").read_text())
+
+    selected = module.selected_artifacts(
+        payload, {"qwen3-8-27b-uncensored-mlx-8bit"}
+    )
+
+    assert {row["path"] for row in selected} == {
+        "8-bit/README.md",
+        "8-bit/chat_template.jinja",
+        "8-bit/config.json",
+        "8-bit/generation_config.json",
+        "8-bit/model-00001-of-00006.safetensors",
+        "8-bit/model-00002-of-00006.safetensors",
+        "8-bit/model-00003-of-00006.safetensors",
+        "8-bit/model-00004-of-00006.safetensors",
+        "8-bit/model-00005-of-00006.safetensors",
+        "8-bit/model-00006-of-00006.safetensors",
+        "8-bit/model.safetensors.index.json",
+        "8-bit/preprocessor_config.json",
+        "8-bit/processor_config.json",
+        "8-bit/tokenizer.json",
+        "8-bit/tokenizer_config.json",
+        "8-bit/video_preprocessor_config.json",
+        "8-bit/vocab.json",
+    }
+    assert {
+        row["revision"] for row in selected
+    } == {"b4603df5fd2a51e7fed2560ee7090caa4e13e4b7"}
+    assert all(
+        row["destination"].startswith("Qwen3.8-27B-Uncensored-MLX/8-bit/")
+        for row in selected
+    )
+
+
 def test_install_artifact_verifies_before_materializing(tmp_path: Path) -> None:
     module = load_script()
     cached = tmp_path / "cache" / "model.gguf"

--- a/tests/test_engine_check.py
+++ b/tests/test_engine_check.py
@@ -34,6 +34,7 @@ def test_registry_contains_every_turbofit_check_engine() -> None:
     assert tuple(spec.engine_id for spec in engine_specs()) == (
         "llama.cpp",
         "mlx",
+        "mtplx",
         "sglang",
         "vllm",
         "freetoken",
@@ -49,9 +50,10 @@ def test_registry_contains_every_turbofit_check_engine() -> None:
 def test_linux_cuda_checks_all_engines_and_admits_native_linux_engines() -> None:
     reports = by_id(check_engines(machine("linux", "x86_64", backend="cuda"), driver_major=580))
 
-    assert set(reports) == {"llama.cpp", "mlx", "sglang", "vllm", "freetoken", "turbohaul-manager"}
+    assert set(reports) == {"llama.cpp", "mlx", "mtplx", "sglang", "vllm", "freetoken", "turbohaul-manager"}
     assert reports["llama.cpp"].compatible
     assert not reports["mlx"].compatible
+    assert not reports["mtplx"].compatible
     assert reports["sglang"].compatible
     assert reports["vllm"].compatible
     assert reports["freetoken"].compatible
@@ -63,6 +65,7 @@ def test_macos_apple_silicon_admits_llama_mlx_and_vllm_metal() -> None:
 
     assert reports["llama.cpp"].compatible
     assert reports["mlx"].compatible
+    assert reports["mtplx"].compatible
     assert reports["vllm"].compatible
     assert not reports["sglang"].compatible
     assert not reports["freetoken"].compatible

--- a/tests/test_gateway_runtime.py
+++ b/tests/test_gateway_runtime.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from turbofit_runtime.gateway_runtime import build_gateway_launch
+
+
+def test_gateway_launch_is_loopback_only_and_uses_exact_route_state(tmp_path: Path) -> None:
+    plugin_root = tmp_path / "plugin"
+    script = plugin_root / "scripts/turbofit-gateway.py"
+    script.parent.mkdir(parents=True)
+    script.write_text("print('gateway')")
+    python = tmp_path / "python"
+    python.write_text("python")
+    python.chmod(0o755)
+    routes = tmp_path / "runtime-state.json"
+
+    launch = build_gateway_launch(
+        python=python,
+        plugin_root=plugin_root,
+        routes_path=routes,
+        port=8091,
+    )
+
+    assert launch.engine_id == "turbofit-gateway"
+    assert launch.model_id == "auto"
+    assert launch.upstream_model_id == "auto"
+    assert launch.required_model_files == ()
+    assert launch.command == (
+        "/usr/bin/env",
+        "TURBOFIT_GATEWAY_HOST=127.0.0.1",
+        "TURBOFIT_GATEWAY_PORT=8091",
+        f"TURBOFIT_RUNTIME_STATE={routes}",
+        str(python),
+        str(script),
+    )

--- a/tests/test_gateway_runtime_cli.py
+++ b/tests/test_gateway_runtime_cli.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+from types import SimpleNamespace
+
+
+ROOT = Path(__file__).parents[1]
+SCRIPT = ROOT / "scripts/turbofit-gateway-runtime"
+
+
+def load_script():
+    loader = SourceFileLoader("turbofit_gateway_runtime", str(SCRIPT))
+    spec = importlib.util.spec_from_loader(loader.name, loader)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class Runtime:
+    def __init__(self) -> None:
+        self.started = []
+        self.stopped = 0
+
+    def start_owned(self, launch, *, timeout_s):
+        self.started.append((launch, timeout_s))
+        return SimpleNamespace(pid=73, owned=True)
+
+    def stop(self):
+        self.stopped += 1
+        return True
+
+
+def test_gateway_cli_starts_owned_loopback_gateway(tmp_path: Path) -> None:
+    module = load_script()
+    runtime = Runtime()
+
+    result = module.run_action(
+        "start",
+        runtime=runtime,
+        python=tmp_path / "python",
+        plugin_root=ROOT,
+        routes_path=tmp_path / "routes.json",
+        port=8091,
+        timeout_s=30,
+    )
+
+    assert result == {"ok": True, "action": "start", "pid": 73, "owned": True}
+    assert runtime.started[0][0].engine_id == "turbofit-gateway"
+
+
+def test_gateway_cli_bootstraps_from_legacy_system_python(tmp_path: Path) -> None:
+    system_python = Path("/usr/bin/python3")
+    if not system_python.exists():
+        return
+    result = subprocess.run(
+        [str(system_python), str(SCRIPT), "status", "--state", str(tmp_path / "missing.json")],
+        text=True,
+        capture_output=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert "unsupported operand type" not in result.stderr
+    assert '"action": "status"' in result.stdout

--- a/tests/test_gateway_runtime_policy.py
+++ b/tests/test_gateway_runtime_policy.py
@@ -75,6 +75,14 @@ def test_health_probe_accepts_native_runtime_health(monkeypatch) -> None:
     assert GATEWAY.check_port(8092) is True
 
 
+def test_backend_state_rejects_a_healthy_listener_serving_the_wrong_model(monkeypatch) -> None:
+    monkeypatch.setattr(GATEWAY, "port_is_open", lambda _port: True)
+    monkeypatch.setattr(GATEWAY, "check_port", lambda _port: True)
+    monkeypatch.setattr(GATEWAY, "served_model_ids", lambda _port: {"another-model"}, raising=False)
+
+    assert GATEWAY.backend_state(18081, "expected-model") == "down"
+
+
 def test_explicit_api_fallback_precedes_interactive_profile_provider(tmp_path, monkeypatch) -> None:
     preferences = tmp_path / "preferences.yaml"
     preferences.write_text(
@@ -174,6 +182,28 @@ def test_dynamic_local_main_and_dedicated_aux_routes(tmp_path, monkeypatch) -> N
     assert main["base_url"] == "http://127.0.0.1:8080"
     assert aux["alias"] == "carwin"
     assert aux["mode"] == "dedicated"
+
+
+def test_local_engine_route_can_separate_stable_alias_from_upstream_model_id(
+    tmp_path, monkeypatch
+) -> None:
+    state = tmp_path / "runtime-state.json"
+    write_state(state, {
+        "main": {
+            "kind": "local",
+            "alias": "qwen3-8-27b-uncensored-mlx-8bit",
+            "model_id": "/models/Qwen3.8-27B-Uncensored-MLX/8-bit",
+            "port": 18081,
+        },
+        "aux": {"kind": "shared-main"},
+    })
+    monkeypatch.setattr(GATEWAY, "RUNTIME_STATE", str(state))
+    monkeypatch.setattr(GATEWAY, "backend_state", lambda _port, _alias=None: "ready")
+
+    main = GATEWAY.runtime_override("main")
+
+    assert main["alias"] == "qwen3-8-27b-uncensored-mlx-8bit"
+    assert main["model_id"] == "/models/Qwen3.8-27B-Uncensored-MLX/8-bit"
 
 
 def test_shared_main_aux_route_follows_current_main_without_restart(tmp_path, monkeypatch) -> None:

--- a/tests/test_managed_engine.py
+++ b/tests/test_managed_engine.py
@@ -1,0 +1,349 @@
+from __future__ import annotations
+
+import fcntl
+import json
+from pathlib import Path
+
+import pytest
+
+from turbofit_runtime.managed_engine import (
+    EngineLaunch,
+    ManagedEngineRuntime,
+    publish_engine_routes,
+)
+
+
+class FakeProcess:
+    def __init__(self, pid: int = 4321) -> None:
+        self.pid = pid
+        self.returncode = None
+
+    def poll(self):
+        return self.returncode
+
+    def terminate(self) -> None:
+        self.returncode = 0
+
+
+
+def launch(tmp_path: Path) -> EngineLaunch:
+    model = tmp_path / "model"
+    model.mkdir()
+    (model / "config.json").write_text("{}")
+    executable = tmp_path / "python"
+    executable.write_text("python")
+    executable.chmod(0o755)
+    return EngineLaunch(
+        engine_id="mlx",
+        model_id="qwen3-8-27b-uncensored-mlx-8bit",
+        model_path=model,
+        port=18081,
+        context_length=262_144,
+        bind_host="127.0.0.1",
+        upstream_model_id=str(model),
+        command=(
+            str(executable),
+            "-m",
+            "mlx_lm",
+            "server",
+            "--model",
+            str(model),
+            "--host",
+            "127.0.0.1",
+            "--port",
+            "18081",
+        ),
+    )
+
+
+def test_owned_engine_is_published_only_after_exact_model_readiness(tmp_path: Path) -> None:
+    spec = launch(tmp_path)
+    state = tmp_path / "owned.json"
+    process = FakeProcess()
+    calls: list[tuple[str, ...]] = []
+    observed_command = ("/real/Python", *spec.command[1:])
+    listeners = iter(((), (process.pid,)))
+
+    runtime = ManagedEngineRuntime(
+        state_path=state,
+        process_factory=lambda command, **_kwargs: calls.append(tuple(command)) or process,
+        command_line=lambda _pid: " ".join(observed_command),
+        listener_pids=lambda _port: next(listeners),
+        json_get=lambda url, _timeout: (
+            {"status": "ok"}
+            if url.endswith("/health")
+            else {"data": [{"id": spec.upstream_model_id}]}
+        ),
+        sleep=lambda _seconds: None,
+        clock=iter((0.0, 0.0)).__next__,
+    )
+
+    resident = runtime.start_owned(spec, timeout_s=1.0)
+
+    assert resident.owned is True
+    assert resident.pid == process.pid
+    assert calls == [spec.command]
+    persisted = json.loads(state.read_text())
+    assert persisted["model_id"] == spec.model_id
+    assert persisted["command"] == list(observed_command)
+
+
+def test_wrong_upstream_model_never_becomes_owned_or_routable(tmp_path: Path) -> None:
+    spec = launch(tmp_path)
+    process = FakeProcess()
+    runtime = ManagedEngineRuntime(
+        state_path=tmp_path / "owned.json",
+        process_factory=lambda _command, **_kwargs: process,
+        listener_pids=lambda _port: (),
+        command_line=lambda _pid: " ".join(spec.command),
+        json_get=lambda url, _timeout: (
+            {"status": "ok"}
+            if url.endswith("/health")
+            else {"data": [{"id": "another-model"}]}
+        ),
+        sleep=lambda _seconds: None,
+        clock=iter((0.0, 2.0)).__next__,
+    )
+
+    with pytest.raises(RuntimeError, match="did not become ready"):
+        runtime.start_owned(spec, timeout_s=1.0)
+
+    assert not (tmp_path / "owned.json").exists()
+
+
+def test_malformed_models_response_fails_closed_as_not_ready(tmp_path: Path) -> None:
+    spec = launch(tmp_path)
+    process = FakeProcess()
+    runtime = ManagedEngineRuntime(
+        state_path=tmp_path / "owned.json",
+        process_factory=lambda _command, **_kwargs: process,
+        listener_pids=lambda _port: (),
+        json_get=lambda _url, _timeout: [],
+        sleep=lambda _seconds: None,
+        clock=iter((0.0, 2.0)).__next__,
+    )
+
+    with pytest.raises(RuntimeError, match="did not become ready"):
+        runtime.start_owned(spec, timeout_s=1.0)
+
+
+def test_external_engine_is_never_signalled(tmp_path: Path) -> None:
+    spec = launch(tmp_path)
+    signalled: list[tuple[int, int]] = []
+    runtime = ManagedEngineRuntime(
+        state_path=tmp_path / "owned.json",
+        command_line=lambda _pid: "external mtplx serve --port 18081",
+        listener_pids=lambda _port: (999,),
+        signal_process=lambda pid, signal: signalled.append((pid, signal)),
+        json_get=lambda url, _timeout: (
+            {"ok": True, "model": spec.model_id}
+            if url.endswith("/health")
+            else {"data": [{"id": spec.upstream_model_id}]}
+        ),
+    )
+
+    resident = runtime.adopt_external(spec, pid=999)
+
+    assert resident.owned is False
+    assert runtime.stop() is True
+    assert signalled == []
+    assert not (tmp_path / "owned.json").exists()
+
+
+def test_external_adoption_requires_reported_pid_to_own_the_listener(tmp_path: Path) -> None:
+    spec = launch(tmp_path)
+    runtime = ManagedEngineRuntime(
+        state_path=tmp_path / "owned.json",
+        listener_pids=lambda _port: (998,),
+        json_get=lambda url, _timeout: (
+            {"status": "ok"}
+            if url.endswith("/health")
+            else {"data": [{"id": spec.upstream_model_id}]}
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="does not own"):
+        runtime.adopt_external(spec, pid=999)
+
+
+def test_recovered_pid_must_still_match_full_recorded_command(tmp_path: Path) -> None:
+    assert not ManagedEngineRuntime._command_matches(
+        ("python", "-m", "server", "--port", "18081"),
+        "python --port 18081 -m server",
+    )
+    spec = launch(tmp_path)
+    state = tmp_path / "owned.json"
+    state.write_text(json.dumps({
+        "schema": "turbofit.managed-engine/v1",
+        "engine_id": spec.engine_id,
+        "model_id": spec.model_id,
+        "model_path": str(spec.model_path),
+        "port": spec.port,
+        "context_length": spec.context_length,
+        "bind_host": spec.bind_host,
+        "upstream_model_id": spec.upstream_model_id,
+        "pid": 4321,
+        "command": list(spec.command),
+        "owned": True,
+        "status": "ready",
+    }))
+    signalled: list[tuple[int, int]] = []
+    runtime = ManagedEngineRuntime(
+        state_path=state,
+        command_line=lambda _pid: "python -m unrelated --port 18081",
+        signal_process=lambda pid, signal: signalled.append((pid, signal)),
+    )
+
+    assert runtime.stop() is False
+    assert signalled == []
+    assert state.exists()
+    assert json.loads(state.read_text())["status"] == "command-mismatch"
+
+
+def test_lifecycle_lock_serializes_cross_process_start_and_stop(tmp_path: Path) -> None:
+    runtime = ManagedEngineRuntime(state_path=tmp_path / "owned.json")
+
+    with runtime._lifecycle_lock():
+        with runtime.lock_path.open("a+") as contender:
+            with pytest.raises(BlockingIOError):
+                fcntl.flock(contender.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+
+
+def test_owned_start_refuses_an_occupied_port_before_spawning(tmp_path: Path) -> None:
+    spec = launch(tmp_path)
+    spawned: list[tuple[str, ...]] = []
+    runtime = ManagedEngineRuntime(
+        state_path=tmp_path / "owned.json",
+        process_factory=lambda command, **_kwargs: spawned.append(tuple(command)),
+        listener_pids=lambda _port: (999,),
+    )
+
+    with pytest.raises(RuntimeError, match="already occupied"):
+        runtime.start_owned(spec)
+
+    assert spawned == []
+
+
+def test_readiness_requires_the_launched_pid_to_own_the_listener(tmp_path: Path) -> None:
+    spec = launch(tmp_path)
+    process = FakeProcess()
+    listeners = iter(((), (999,), (999,)))
+    runtime = ManagedEngineRuntime(
+        state_path=tmp_path / "owned.json",
+        process_factory=lambda _command, **_kwargs: process,
+        command_line=lambda _pid: " ".join(spec.command),
+        listener_pids=lambda _port: next(listeners, (999,)),
+        json_get=lambda url, _timeout: (
+            {"status": "ok"}
+            if url.endswith("/health")
+            else {"data": [{"id": spec.upstream_model_id}]}
+        ),
+        sleep=lambda _seconds: None,
+        clock=iter((0.0, 0.0, 0.0, 2.0)).__next__,
+    )
+
+    with pytest.raises(RuntimeError, match="did not become ready"):
+        runtime.start_owned(spec, timeout_s=1.0)
+
+    assert process.returncode == 0
+
+
+def test_non_loopback_bind_is_rejected_even_if_another_argument_mentions_localhost(
+    tmp_path: Path,
+) -> None:
+    spec = launch(tmp_path)
+    with pytest.raises(ValueError, match="loopback"):
+        EngineLaunch(
+            **{
+                **spec.__dict__,
+                "bind_host": "0.0.0.0",
+                "command": (*spec.command, "/tmp/localhost-cache"),
+            }
+        )
+
+
+def test_owned_stop_waits_for_verified_process_exit(tmp_path: Path) -> None:
+    spec = launch(tmp_path)
+    state = tmp_path / "owned.json"
+    state.write_text(json.dumps({
+        "schema": "turbofit.managed-engine/v1",
+        "engine_id": spec.engine_id,
+        "model_id": spec.model_id,
+        "model_path": str(spec.model_path),
+        "port": spec.port,
+        "context_length": spec.context_length,
+        "bind_host": spec.bind_host,
+        "upstream_model_id": spec.upstream_model_id,
+        "pid": 77,
+        "command": list(spec.command),
+        "owned": True,
+        "status": "ready",
+    }))
+    observed = iter((" ".join(spec.command), " ".join(spec.command), ""))
+    signals: list[tuple[int, int]] = []
+    sleeps: list[float] = []
+    runtime = ManagedEngineRuntime(
+        state_path=state,
+        command_line=lambda _pid: next(observed, ""),
+        signal_process=lambda pid, sig: signals.append((pid, sig)),
+        sleep=lambda seconds: sleeps.append(seconds),
+        clock=iter((0.0, 0.0, 0.1)).__next__,
+    )
+
+    assert runtime.stop(timeout_s=5.0) is True
+    assert len(signals) == 1
+    assert sleeps
+    assert not state.exists()
+
+
+def test_status_reports_stale_state_instead_of_treating_file_existence_as_health(
+    tmp_path: Path,
+) -> None:
+    spec = launch(tmp_path)
+    state = tmp_path / "owned.json"
+    state.write_text(json.dumps({
+        "schema": "turbofit.managed-engine/v1",
+        "engine_id": spec.engine_id,
+        "model_id": spec.model_id,
+        "model_path": str(spec.model_path),
+        "port": spec.port,
+        "context_length": spec.context_length,
+        "bind_host": spec.bind_host,
+        "upstream_model_id": spec.upstream_model_id,
+        "pid": 77,
+        "command": list(spec.command),
+        "owned": True,
+        "status": "ready",
+    }))
+    runtime = ManagedEngineRuntime(
+        state_path=state,
+        command_line=lambda _pid: "",
+        listener_pids=lambda _port: (),
+    )
+
+    result = runtime.inspect()
+
+    assert result["ok"] is False
+    assert result["status"] == "stale"
+    assert state.exists()
+
+
+def test_engine_routes_use_real_upstream_model_id_and_shared_aux(tmp_path: Path) -> None:
+    spec = launch(tmp_path)
+    path = tmp_path / "runtime-state.json"
+
+    publish_engine_routes(path, spec)
+
+    payload = json.loads(path.read_text())
+    assert payload["active"] == "apple-mlx"
+    assert payload["routes"] == {
+        "main": {
+            "kind": "local",
+            "alias": spec.model_id,
+            "model_id": spec.upstream_model_id,
+            "port": 18081,
+            "context_length": 262_144,
+            "engine": "mlx",
+        },
+        "aux": {"kind": "shared-main", "context_length": 262_144},
+    }

--- a/tests/test_mlx_runtime_cli.py
+++ b/tests/test_mlx_runtime_cli.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+from types import SimpleNamespace
+
+
+ROOT = Path(__file__).parents[1]
+SCRIPT = ROOT / "scripts/turbofit-mlx-runtime"
+
+
+def load_script():
+    loader = SourceFileLoader("turbofit_mlx_runtime", str(SCRIPT))
+    spec = importlib.util.spec_from_loader(loader.name, loader)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class Runtime:
+    def __init__(self) -> None:
+        self.started = []
+        self.stopped = 0
+
+    def start_owned(self, launch, *, timeout_s):
+        self.started.append((launch, timeout_s))
+        return SimpleNamespace(pid=42, owned=True)
+
+    def stop(self):
+        self.stopped += 1
+        return True
+
+
+def test_start_publishes_routes_only_after_runtime_verifies(tmp_path: Path) -> None:
+    module = load_script()
+    runtime = Runtime()
+    routes = tmp_path / "routes.json"
+    model_root = tmp_path / "models"
+    runtime_root = tmp_path / "runtimes"
+
+    result = module.run_action(
+        "start",
+        runtime=runtime,
+        model_root=model_root,
+        runtime_root=runtime_root,
+        routes_path=routes,
+        port=18081,
+        timeout_s=30,
+    )
+
+    assert result == {"ok": True, "action": "start", "pid": 42, "owned": True}
+    assert runtime.started[0][1] == 30
+    assert json.loads(routes.read_text())["active"] == "apple-mlx"
+
+
+def test_stop_removes_only_the_apple_mlx_route(tmp_path: Path) -> None:
+    module = load_script()
+    runtime = Runtime()
+    routes = tmp_path / "routes.json"
+    routes.write_text(json.dumps({"active": "apple-mlx", "routes": {}}))
+
+    result = module.run_action(
+        "stop",
+        runtime=runtime,
+        model_root=tmp_path / "models",
+        runtime_root=tmp_path / "runtimes",
+        routes_path=routes,
+        port=18081,
+        timeout_s=30,
+    )
+
+    assert result == {"ok": True, "action": "stop"}
+    assert runtime.stopped == 1
+    assert not routes.exists()
+
+
+def test_cli_reexecutes_from_legacy_system_python_before_importing_runtime(tmp_path: Path) -> None:
+    system_python = Path("/usr/bin/python3")
+    if not system_python.exists():
+        return
+    result = subprocess.run(
+        [str(system_python), str(SCRIPT), "status", "--state", str(tmp_path / "missing.json")],
+        text=True,
+        capture_output=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert "unsupported operand type" not in result.stderr
+    assert json.loads(result.stdout)["action"] == "status"

--- a/tests/test_mlx_runtime_installer.py
+++ b/tests/test_mlx_runtime_installer.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).parents[1]
+SCRIPT = ROOT / "scripts/install-mlx-runtime"
+
+
+def load_script():
+    loader = SourceFileLoader("install_mlx_runtime", str(SCRIPT))
+    spec = importlib.util.spec_from_loader(loader.name, loader)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_installer_creates_isolated_pinned_mlx_runtime(tmp_path: Path) -> None:
+    module = load_script()
+    calls: list[list[str]] = []
+
+    def run(command, **_kwargs):
+        calls.append(list(command))
+        if command[1] == "venv":
+            python = tmp_path / "mlx-lm-0.31.3/.venv/bin/python"
+            python.parent.mkdir(parents=True)
+            python.write_text("python")
+            python.chmod(0o755)
+
+    record = module.install(
+        runtime_root=tmp_path,
+        uv="/opt/homebrew/bin/uv",
+        platform_name="darwin",
+        architecture="arm64",
+        run=run,
+        version_probe=lambda _python: {"mlx": "0.32.2", "mlx-lm": "0.31.3"},
+    )
+
+    python = tmp_path / "mlx-lm-0.31.3/.venv/bin/python"
+    assert calls == [
+        [
+            "/opt/homebrew/bin/uv",
+            "venv",
+            "--python",
+            "3.12",
+            str(tmp_path / "mlx-lm-0.31.3/.venv"),
+        ],
+        [
+            "/opt/homebrew/bin/uv",
+            "pip",
+            "install",
+            "--python",
+            str(python),
+            "mlx==0.32.2",
+            "mlx-lm==0.31.3",
+        ],
+    ]
+    assert record["status"] == "verified"
+    assert record["python"] == str(python)
+
+
+def test_installer_fails_closed_off_apple_silicon(tmp_path: Path) -> None:
+    module = load_script()
+
+    with pytest.raises(RuntimeError, match="Apple Silicon"):
+        module.install(
+            runtime_root=tmp_path,
+            uv="uv",
+            platform_name="linux",
+            architecture="x86_64",
+        )
+
+
+def test_installer_help_bootstraps_from_legacy_system_python() -> None:
+    system_python = Path("/usr/bin/python3")
+    if not system_python.exists():
+        return
+    result = subprocess.run(
+        [str(system_python), str(SCRIPT), "--help"],
+        text=True,
+        capture_output=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert "unsupported operand type" not in result.stderr
+    assert "Install or verify" in result.stdout

--- a/tests/test_mtplx_engine.py
+++ b/tests/test_mtplx_engine.py
@@ -7,6 +7,8 @@ from turbofit_runtime.engine_check import engine_specs
 from turbofit_runtime.mtplx_engine import (
     MTPLX_QUALITY_MODEL,
     MTPLX_SPEED_MODEL,
+    MTPLX_FLASH_BARE_SPEED,
+    MTPLX_FLASH_OPTIMIZED_SPEED,
     build_mtplx_launch,
     canonical_mtplx_alias,
     discover_mtplx,
@@ -124,6 +126,35 @@ def test_cached_mtplx_paths_map_to_stable_turbofit_aliases() -> None:
     assert canonical_mtplx_alias(
         "/models/Youssofal--Qwen3.8-27B-MTPLX-Optimized-Quality"
     ) == "qwen3-8-27b-mtplx-optimized-quality"
+    assert canonical_mtplx_alias(
+        "/models/Youssofal--Qwen3.8-Flash-Next-MTPLX-Bare-Speed"
+    ) == "qwen3-8-flash-next-mtplx-bare-speed"
+    assert canonical_mtplx_alias(
+        "/models/Youssofal--Qwen3.8-Flash-Next-MTPLX-Optimized-Speed"
+    ) == "qwen3-8-flash-next-mtplx-optimized-speed"
+
+
+def test_flash_next_models_are_supported_engine_candidates(tmp_path: Path) -> None:
+    executable = tmp_path / "mtplx"
+    executable.write_text("mtplx")
+    executable.chmod(0o755)
+    model = tmp_path / "flash"
+    model.mkdir()
+    (model / "config.json").write_text("{}")
+
+    for repository, alias in (
+        (MTPLX_FLASH_BARE_SPEED, "qwen3-8-flash-next-mtplx-bare-speed"),
+        (MTPLX_FLASH_OPTIMIZED_SPEED, "qwen3-8-flash-next-mtplx-optimized-speed"),
+    ):
+        launch = build_mtplx_launch(
+            executable=executable,
+            model_path=model,
+            model_repo=repository,
+            model_id=alias,
+            port=18082,
+        )
+        assert launch.model_id == alias
+        assert launch.context_length == 262_144
 
 
 def test_telemetry_preserves_measured_fields_without_inventing_tps() -> None:

--- a/tests/test_mtplx_engine.py
+++ b/tests/test_mtplx_engine.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from turbofit_runtime.engine_check import engine_specs
+from turbofit_runtime.mtplx_engine import (
+    MTPLX_QUALITY_MODEL,
+    MTPLX_SPEED_MODEL,
+    build_mtplx_launch,
+    canonical_mtplx_alias,
+    discover_mtplx,
+    mtplx_telemetry,
+)
+
+
+ROOT = Path(__file__).parents[1]
+
+
+def test_distribution_includes_mtplx_runtime_adapter() -> None:
+    distribution = (ROOT / "distribution.yaml").read_text()
+    assert "  - scripts/turbofit-mtplx-runtime\n" in distribution
+
+
+def test_engine_registry_exposes_mtplx_as_endpoint_discoverable() -> None:
+    specs = {item.engine_id: item for item in engine_specs()}
+
+    assert specs["mtplx"].openai_port == 8000
+    assert specs["mtplx"].endpoint_discoverable is True
+    assert specs["mtplx"].commands == ("mtplx",)
+
+
+def test_discovery_reads_app_port_and_requires_mtplx_health(tmp_path: Path) -> None:
+    settings = tmp_path / "settings.json"
+    settings.write_text(json.dumps({"host": "127.0.0.1", "port": 18086}))
+    calls: list[str] = []
+
+    result = discover_mtplx(
+        settings_path=settings,
+        json_get=lambda url, _timeout: calls.append(url) or {
+            "ok": True,
+            "model": "qwen38-mtplx-speed",
+            "model_path": "/models/speed",
+            "generation_mode": "mtp",
+            "depth": 3,
+            "startup": {"pid": 4321, "launch_id": "app-owned"},
+        },
+    )
+
+    assert calls == ["http://127.0.0.1:18086/health"]
+    assert result.port == 18086
+    assert result.pid == 4321
+    assert result.owned_by_turbofit is False
+    assert result.app_launch_id == "app-owned"
+
+
+def test_discovery_probes_turbofit_owned_mtplx_port_without_app_settings(tmp_path: Path) -> None:
+    calls: list[str] = []
+
+    def get(url, _timeout):
+        calls.append(url)
+        if url != "http://127.0.0.1:18082/health":
+            raise OSError("closed")
+        return {
+            "ok": True,
+            "model": "qwen3-8-27b-mtplx-optimized-speed",
+            "model_path": "/models/Youssofal--Qwen3.8-27B-MTPLX-Optimized-Speed",
+            "startup": {"pid": 77},
+        }
+
+    result = discover_mtplx(settings_path=tmp_path / "missing.json", json_get=get)
+
+    assert result is not None
+    assert result.port == 18082
+    assert "http://127.0.0.1:18082/health" in calls
+
+
+def test_owned_mtplx_launch_uses_published_model_contract(tmp_path: Path) -> None:
+    executable = tmp_path / "mtplx"
+    executable.write_text("mtplx")
+    executable.chmod(0o755)
+    model = tmp_path / "quality"
+    model.mkdir()
+    (model / "config.json").write_text("{}")
+
+    launch = build_mtplx_launch(
+        executable=executable,
+        model_path=model,
+        model_repo=MTPLX_QUALITY_MODEL,
+        model_id="qwen38-mtplx-quality",
+        port=18082,
+    )
+
+    assert MTPLX_SPEED_MODEL == "Youssofal/Qwen3.8-27B-MTPLX-Optimized-Speed"
+    assert launch.engine_id == "mtplx"
+    assert launch.model_id == "qwen38-mtplx-quality"
+    assert launch.upstream_model_id == "qwen38-mtplx-quality"
+    assert launch.command == (
+        str(executable),
+        "serve",
+        "--model",
+        str(model),
+        "--profile",
+        "turbo",
+        "--host",
+        "127.0.0.1",
+        "--port",
+        "18082",
+        "--no-auth",
+        "--model-id",
+        "qwen38-mtplx-quality",
+        "--generation-mode",
+        "mtp",
+        "--fan-mode",
+        "default",
+        "--no-stats-footer",
+    )
+
+
+def test_cached_mtplx_paths_map_to_stable_turbofit_aliases() -> None:
+    assert canonical_mtplx_alias(
+        "/models/Youssofal--Qwen3.8-27B-MTPLX-Optimized-Speed"
+    ) == "qwen3-8-27b-mtplx-optimized-speed"
+    assert canonical_mtplx_alias(
+        "/models/Youssofal--Qwen3.8-27B-MTPLX-Optimized-Quality"
+    ) == "qwen3-8-27b-mtplx-optimized-quality"
+
+
+def test_telemetry_preserves_measured_fields_without_inventing_tps() -> None:
+    payload = mtplx_telemetry({
+        "ok": True,
+        "model": "qwen38-mtplx-speed",
+        "generation_mode": "mtp",
+        "depth": 3,
+        "scheduler": {"mode": "serial", "active_requests": 0},
+        "memory_plan": {"model_weights_bytes": 123, "context_window_resolved": 262144},
+    }, {
+        "latest": {
+            "decode_tok_s": 58.2,
+            "request_tok_s": 55.1,
+            "request_effective_mtp_depth": 3,
+            "peak_memory_bytes": 456,
+        }
+    })
+
+    assert payload["decode_tokens_per_second"] == 58.2
+    assert payload["request_tokens_per_second"] == 55.1
+    assert payload["peak_memory_bytes"] == 456
+    assert payload["acceptance_rate"] is None
+    assert payload["context_length"] == 262144
+    assert payload["scheduler_mode"] == "serial"
+
+    unmeasured = mtplx_telemetry({"ok": True, "model": "qwen38-mtplx-speed"})
+    assert unmeasured["decode_tokens_per_second"] is None

--- a/tests/test_mtplx_engine.py
+++ b/tests/test_mtplx_engine.py
@@ -108,6 +108,8 @@ def test_owned_mtplx_launch_uses_published_model_contract(tmp_path: Path) -> Non
         "127.0.0.1",
         "--port",
         "18082",
+        "--depth",
+        "3",
         "--no-auth",
         "--model-id",
         "qwen38-mtplx-quality",
@@ -155,6 +157,8 @@ def test_flash_next_models_are_supported_engine_candidates(tmp_path: Path) -> No
         )
         assert launch.model_id == alias
         assert launch.context_length == 262_144
+        expected_depth = "2" if repository == MTPLX_FLASH_BARE_SPEED else "3"
+        assert launch.command[launch.command.index("--depth") + 1] == expected_depth
 
 
 def test_telemetry_preserves_measured_fields_without_inventing_tps() -> None:

--- a/tests/test_mtplx_runtime_cli.py
+++ b/tests/test_mtplx_runtime_cli.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+from dataclasses import replace
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from turbofit_runtime.mtplx_engine import MtplxEndpoint
+
+
+ROOT = Path(__file__).parents[1]
+SCRIPT = ROOT / "scripts/turbofit-mtplx-runtime"
+
+
+def load_script():
+    loader = SourceFileLoader("turbofit_mtplx_runtime", str(SCRIPT))
+    spec = importlib.util.spec_from_loader(loader.name, loader)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class Runtime:
+    def __init__(self) -> None:
+        self.adopted = []
+        self.started = []
+        self.stopped = 0
+
+    def adopt_external(self, launch, *, pid):
+        self.adopted.append((launch, pid))
+        return SimpleNamespace(pid=pid, owned=False)
+
+    def start_owned(self, launch, *, timeout_s):
+        self.started.append((launch, timeout_s))
+        return SimpleNamespace(pid=77, owned=True)
+
+    def stop(self):
+        self.stopped += 1
+        return False
+
+    def inspect(self):
+        return {
+            "ok": True,
+            "status": "ready",
+            "runtime": {"pid": 4321, "port": 18086, "owned": True},
+        }
+
+
+def endpoint() -> MtplxEndpoint:
+    return MtplxEndpoint(
+        host="127.0.0.1",
+        port=18086,
+        model_id="served-speed",
+        model_path="/models/Youssofal--Qwen3.8-27B-MTPLX-Optimized-Speed",
+        pid=4321,
+        app_launch_id="app-launch",
+        health={"ok": True, "model": "served-speed"},
+    )
+
+
+def test_adopt_routes_external_mtplx_without_taking_process_ownership(tmp_path: Path) -> None:
+    module = load_script()
+    runtime = Runtime()
+    routes = tmp_path / "routes.json"
+
+    result = module.run_action(
+        "adopt",
+        runtime=runtime,
+        routes_path=routes,
+        discover=lambda: endpoint(),
+        executable=tmp_path / "mtplx",
+        model_path=None,
+        model_repo=None,
+        model_id=None,
+        port=8000,
+        timeout_s=30,
+    )
+
+    assert result["owned"] is False
+    assert result["pid"] == 4321
+    assert runtime.adopted[0][1] == 4321
+    state = json.loads(routes.read_text())
+    assert state["routes"]["main"]["alias"] == "qwen3-8-27b-mtplx-optimized-speed"
+    assert state["routes"]["main"]["model_id"] == "served-speed"
+    assert state["routes"]["main"]["port"] == 18086
+
+
+def test_adopt_fails_cleanly_when_external_mtplx_does_not_report_a_pid(tmp_path: Path) -> None:
+    module = load_script()
+    runtime = Runtime()
+
+    with pytest.raises(RuntimeError, match="does not report a PID"):
+        module.run_action(
+            "adopt",
+            runtime=runtime,
+            routes_path=tmp_path / "routes.json",
+            discover=lambda: replace(endpoint(), pid=None),
+            executable=tmp_path / "mtplx",
+            model_path=None,
+            model_repo=None,
+            model_id=None,
+            port=8000,
+            timeout_s=30,
+        )
+
+
+def test_stop_never_signals_adopted_external_mtplx(tmp_path: Path) -> None:
+    module = load_script()
+    runtime = Runtime()
+    routes = tmp_path / "routes.json"
+    routes.write_text(json.dumps({"active": "apple-mtplx", "routes": {}}))
+
+    result = module.run_action(
+        "stop",
+        runtime=runtime,
+        routes_path=routes,
+        discover=lambda: endpoint(),
+        executable=tmp_path / "mtplx",
+        model_path=None,
+        model_repo=None,
+        model_id=None,
+        port=8000,
+        timeout_s=30,
+    )
+
+    assert runtime.stopped == 1
+    assert result == {"ok": True, "action": "detach", "process_stopped": False}
+    assert not routes.exists()
+
+
+def test_status_distinguishes_turbofit_owned_mtplx(tmp_path: Path) -> None:
+    module = load_script()
+
+    result = module.run_action(
+        "status",
+        runtime=Runtime(),
+        routes_path=tmp_path / "routes.json",
+        discover=lambda: endpoint(),
+        executable=tmp_path / "mtplx",
+        model_path=None,
+        model_repo=None,
+        model_id=None,
+        port=8000,
+        timeout_s=30,
+    )
+
+    assert result["endpoint"]["owned_by_turbofit"] is True
+    assert result["endpoint"]["lifecycle_status"] == "ready"
+
+
+def test_cli_reexecutes_from_legacy_system_python_before_runtime_imports(tmp_path: Path) -> None:
+    system_python = Path("/usr/bin/python3")
+    if not system_python.exists():
+        return
+    result = subprocess.run(
+        [str(system_python), str(SCRIPT), "status", "--state", str(tmp_path / "missing.json")],
+        text=True,
+        capture_output=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert "unsupported operand type" not in result.stderr
+    assert json.loads(result.stdout)["action"] == "status"

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -6,6 +6,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 
 ROOT = Path(__file__).parents[1]
 
@@ -448,6 +450,176 @@ def test_apply_configuration_can_install_lemonade_runtime(monkeypatch) -> None:
     assert result["lemonade"] == {"status": "verified", "version": "11.5.1"}
 
 
+def test_apply_configuration_activates_managed_apple_mlx_stack(monkeypatch) -> None:
+    import types
+    import plugin_tools
+    from turbofit_runtime.hardware import AcceleratorDevice, HardwareFingerprint
+
+    hardware = HardwareFingerprint(
+        os="darwin",
+        architecture="arm64",
+        system_ram_mb=128 * 1024,
+        devices=(AcceleratorDevice(
+            index=0,
+            uuid="apple-unified-memory",
+            name="Apple Silicon Unified Memory",
+            vendor="apple",
+            backend="metal",
+            memory_total_mb=120 * 1024,
+            compute_capability=None,
+            bus_id=None,
+        ),),
+    )
+    hermes_package = types.ModuleType("hermes_cli")
+    hermes_config = types.ModuleType("hermes_cli.config")
+    setattr(hermes_config, "load_config", lambda: {})
+    setattr(hermes_config, "save_config", lambda *_args, **_kwargs: None)
+    monkeypatch.setitem(sys.modules, "hermes_cli", hermes_package)
+    monkeypatch.setitem(sys.modules, "hermes_cli.config", hermes_config)
+    monkeypatch.setattr(plugin_tools, "probe_hardware", lambda: hardware, raising=False)
+    monkeypatch.setattr(
+        plugin_tools,
+        "ensure_recommended_models",
+        lambda **kwargs: {"ok": True, "families": kwargs["families"], "artifacts": []},
+    )
+    monkeypatch.setattr(
+        plugin_tools,
+        "install_mlx_runtime",
+        lambda: {"status": "verified", "versions": {"mlx-lm": "0.31.3"}},
+        raising=False,
+    )
+    monkeypatch.setattr(
+        plugin_tools,
+        "activate_apple_mlx_stack",
+        lambda: {"ok": True, "engine": "mlx", "gateway": "ready"},
+        raising=False,
+    )
+    monkeypatch.setattr(
+        plugin_tools,
+        "select_profile",
+        lambda _profile: (_ for _ in ()).throw(AssertionError("GGUF profile must not be selected")),
+    )
+
+    result = plugin_tools.apply_configuration(
+        primary=False,
+        fallback=None,
+        profile="auto",
+        base_url=None,
+        install_native=True,
+    )
+
+    assert result["models"]["families"] == ["qwen3-8-27b-uncensored-mlx-8bit"]
+    assert result["mlx_runtime"]["status"] == "verified"
+    assert result["selection"]["engine"] == "mlx"
+
+
+def test_apply_configuration_requires_explicit_native_install_for_apple_mlx(monkeypatch) -> None:
+    import types
+    import plugin_tools
+    from turbofit_runtime.hardware import AcceleratorDevice, HardwareFingerprint
+
+    hardware = HardwareFingerprint(
+        os="darwin", architecture="arm64", system_ram_mb=128 * 1024,
+        devices=(AcceleratorDevice(
+            index=0, uuid="apple-unified-memory", name="Apple Unified Memory",
+            vendor="apple", backend="metal", memory_total_mb=120 * 1024,
+            compute_capability=None, bus_id=None,
+        ),),
+    )
+    hermes_package = types.ModuleType("hermes_cli")
+    hermes_config = types.ModuleType("hermes_cli.config")
+    setattr(hermes_config, "load_config", lambda: {})
+    setattr(hermes_config, "save_config", lambda *_args, **_kwargs: None)
+    monkeypatch.setitem(sys.modules, "hermes_cli", hermes_package)
+    monkeypatch.setitem(sys.modules, "hermes_cli.config", hermes_config)
+    monkeypatch.setattr(plugin_tools, "probe_hardware", lambda: hardware)
+    monkeypatch.setattr(
+        plugin_tools,
+        "ensure_recommended_models",
+        lambda **_kwargs: (_ for _ in ()).throw(AssertionError("must fail before download")),
+    )
+
+    with pytest.raises(ValueError, match="install_native=true"):
+        plugin_tools.apply_configuration(
+            primary=False, fallback=None, profile="auto", base_url=None,
+        )
+
+
+def test_apply_configuration_blocks_unpinned_lower_memory_apple_mlx(monkeypatch) -> None:
+    import types
+    import plugin_tools
+    from turbofit_runtime.hardware import AcceleratorDevice, HardwareFingerprint
+
+    hardware = HardwareFingerprint(
+        os="darwin", architecture="arm64", system_ram_mb=32 * 1024,
+        devices=(AcceleratorDevice(
+            index=0, uuid="apple-unified-memory", name="Apple Unified Memory",
+            vendor="apple", backend="metal", memory_total_mb=30 * 1024,
+            compute_capability=None, bus_id=None,
+        ),),
+    )
+    hermes_package = types.ModuleType("hermes_cli")
+    hermes_config = types.ModuleType("hermes_cli.config")
+    setattr(hermes_config, "load_config", lambda: {})
+    setattr(hermes_config, "save_config", lambda *_args, **_kwargs: None)
+    monkeypatch.setitem(sys.modules, "hermes_cli", hermes_package)
+    monkeypatch.setitem(sys.modules, "hermes_cli.config", hermes_config)
+    monkeypatch.setattr(plugin_tools, "probe_hardware", lambda: hardware)
+    monkeypatch.setattr(
+        plugin_tools,
+        "ensure_recommended_models",
+        lambda **_kwargs: (_ for _ in ()).throw(AssertionError("must fail before download")),
+    )
+
+    with pytest.raises(RuntimeError, match="not pinned"):
+        plugin_tools.apply_configuration(
+            primary=False, fallback=None, profile="auto", base_url=None,
+            install_native=True,
+        )
+
+
+def test_apple_mlx_activation_failure_restores_previous_hermes_config(monkeypatch) -> None:
+    import types
+    import plugin_tools
+    from turbofit_runtime.hardware import AcceleratorDevice, HardwareFingerprint
+
+    hardware = HardwareFingerprint(
+        os="darwin", architecture="arm64", system_ram_mb=128 * 1024,
+        devices=(AcceleratorDevice(
+            index=0, uuid="apple-unified-memory", name="Apple Unified Memory",
+            vendor="apple", backend="metal", memory_total_mb=120 * 1024,
+            compute_capability=None, bus_id=None,
+        ),),
+    )
+    original = {"model": {"default": "old-model", "provider": "old-provider"}}
+    saved = []
+    hermes_package = types.ModuleType("hermes_cli")
+    hermes_config = types.ModuleType("hermes_cli.config")
+    setattr(hermes_config, "load_config", lambda: original)
+    setattr(hermes_config, "save_config", lambda value, **_kwargs: saved.append(value))
+    monkeypatch.setitem(sys.modules, "hermes_cli", hermes_package)
+    monkeypatch.setitem(sys.modules, "hermes_cli.config", hermes_config)
+    monkeypatch.setattr(plugin_tools, "probe_hardware", lambda: hardware)
+    monkeypatch.setattr(
+        plugin_tools, "ensure_recommended_models",
+        lambda **kwargs: {"ok": True, "families": kwargs["families"], "artifacts": []},
+    )
+    monkeypatch.setattr(plugin_tools, "install_mlx_runtime", lambda: {"status": "verified"})
+    monkeypatch.setattr(
+        plugin_tools, "activate_apple_mlx_stack",
+        lambda: (_ for _ in ()).throw(RuntimeError("activation failed")),
+    )
+
+    with pytest.raises(RuntimeError, match="activation failed"):
+        plugin_tools.apply_configuration(
+            primary=True, fallback=None, profile="auto", base_url=None,
+            install_native=True,
+        )
+
+    assert len(saved) == 2
+    assert saved[-1] == original
+
+
 def test_apply_configuration_can_install_native_runtime(monkeypatch) -> None:
     import types
     import plugin_tools
@@ -864,3 +1036,30 @@ def test_select_profile_skips_systemctl_on_windows(monkeypatch) -> None:
     assert payload["configured"] is True
     assert payload["controller_restarted"] is False
     assert all(command[0] != "systemctl" for command in seen)
+
+
+def test_recommended_artifacts_follow_apple_mlx_lane() -> None:
+    import plugin_tools
+    from turbofit_runtime.hardware import AcceleratorDevice, HardwareFingerprint
+
+    hardware = HardwareFingerprint(
+        os="darwin",
+        architecture="arm64",
+        system_ram_mb=128 * 1024,
+        devices=(
+            AcceleratorDevice(
+                index=0,
+                uuid="apple-unified-memory",
+                name="Apple Silicon Unified Memory",
+                vendor="apple",
+                backend="metal",
+                memory_total_mb=120 * 1024,
+                compute_capability=None,
+                bus_id=None,
+            ),
+        ),
+    )
+
+    assert plugin_tools.recommended_artifact_families(hardware=hardware) == [
+        "qwen3-8-27b-uncensored-mlx-8bit"
+    ]

--- a/tests/test_release_version.py
+++ b/tests/test_release_version.py
@@ -49,3 +49,15 @@ def test_readme_qwen_variants_match_active_catalog() -> None:
     readme = (ROOT / "README.md").read_text()
     assert "Qwen 3.8 27B Unleashed" in readme
     assert "Ornith 1.5 35A3B" in readme
+
+
+def test_distribution_includes_managed_apple_mlx_runtime_files() -> None:
+    distribution = yaml.safe_load((ROOT / "distribution.yaml").read_text())
+    owned = set(distribution["distribution_owned"])
+
+    assert {
+        "references/python-runtimes.json",
+        "scripts/install-mlx-runtime",
+        "scripts/turbofit-gateway-runtime",
+        "scripts/turbofit-mlx-runtime",
+    } <= owned


### PR DESCRIPTION
Title: Add MTPLX runtime adapter for Apple Silicon

Proposed stacked base: feat/apple-mlx-runtime @ 5696b84a6b3d25c61e09ea11451ec2225491422c
Head: feat/mtplx-engine @ 6b63b68c72ab4af12bbd6750bf9375f835a7ebfd

Summary

Draft stacking note: this PR depends on #30. GitHub cannot use a contributor-fork branch as the base of an upstream PR, so the temporary GitHub base is `main` and the visible diff includes #30. After #30 lands, this branch will be rebased onto current `main` and the PR will be marked ready without changing the MTPLX commit scope.

Add MTPLX 2.10.1 as a first-class Apple Silicon engine behind Turbofit's stable local routes. The adapter supports ownership-safe Turbofit launches and route-only adoption of an already-running MTPLX app/CLI server, reuses existing model caches, reports health and measured telemetry, and never signals externally managed processes.

Problem

Turbofit currently has no MTPLX engine entry, cannot discover an app-managed MTPLX daemon, cannot route MTPLX models through `auto`, and cannot distinguish an externally managed server from a Turbofit-owned process. This prevents Apple users from combining MTPLX's MTP-specialized runtime with Turbofit's stable provider and evidence model.

Implementation

- Register MTPLX 2.10.1 at source revision `557e637a3aceba4cad7975582979e434aea7c092` as an Apple Silicon/Metal engine.
- Discover MTPLX through its persisted app port and loopback health API.
- Validate exact model ID, model path, health PID, and listening PID before adoption.
- Add stable aliases for Optimized Speed and Optimized Quality.
- Add candidate aliases and cached-artifact support for Qwen 3.8 Flash Next Bare Speed and Optimized Speed.
- Launch each model at its measured winning depth: D2 for Flash Next Bare Speed and D3 for the 27B and Flash Next Optimized variants.
- Support two explicit lifecycle modes:
  - Turbofit-owned start/stop with exact PID, argv, and listener verification;
  - external adopt/detach with no process signal.
- Fix route detach to remove `apple-mtplx` state.
- Distinguish app-managed, external, and Turbofit-owned status.
- Normalize `/health` and `/metrics` into model, generation mode, MTP depth, scheduler state, context, memory, and measured request/decode throughput without inventing absent values.
- Route main and shared-main auxiliary roles through stable Turbofit IDs.
- Include the runtime adapter in the plugin distribution.

Safety

- MTPLX endpoints must be healthy loopback listeners.
- A missing or non-listening health PID is rejected.
- External adoption is non-owning and never persists signal authority.
- Detach removes only Turbofit routing; it does not stop the external app/server.
- Owned stop inherits the hardened exact PID + argv + listener checks from the generic managed runtime.
- No model is downloaded when a validated cached MTPLX artifact already exists.

Measured Apple evidence

Exact test machine: Apple M5 Max, 128 GiB unified memory, macOS 26.6.1.

Turbofit cross-engine screening:

- Optimized Speed: pass; 41.975003 effective output tok/s; 671.839 ms mean short-suite TTFT.
- Optimized Quality: pass; 38.435599 effective output tok/s; 688.519667 ms mean short-suite TTFT.

Extended 8K/32K/64K suite:

- Optimized Speed: pass; context 1.0; 66.463529 effective output tok/s; 65,564 MiB peak unified memory.
- Optimized Quality: pass; context 1.0; 45.653045 effective output tok/s; 73,475 MiB peak unified memory.

MTPLX internal matched 512-token tune:

- Speed AR/D1/D2/D3: 24.577993 / 55.733721 / 72.016063 / 80.746383 end-to-end tok/s; D3 wins.
- Quality AR/D1/D2/D3: 16.929983 / 41.670293 / 55.835606 / 57.641899 end-to-end tok/s; D3 wins.

Qwen 3.8 Flash Next extended 8K/32K/64K suite:

- Bare Speed: pass; context 1.0; 85.343646 effective output tok/s; 105,851 MiB peak unified memory.
- Optimized Speed: pass; context 1.0; 85.580633 effective output tok/s; 113,521 MiB peak unified memory.

Flash Next matched 512-token AR/depth sweep:

- Bare Speed AR/D1/D2/D3/D4/D5: 44.963166 / 71.552248 / 95.251886 / 85.303066 / 86.392667 / 73.998435 end-to-end tok/s; D2 wins.
- Optimized Speed AR/D1/D2/D3/D4/D5: 43.501900 / 63.454447 / 89.707503 / 90.963623 / 72.459613 / 84.138004 end-to-end tok/s; D3 wins.

`mtplx bench tune` does not support the `qwen4_exp` family. `mtplx bench run` was also blocked before model load by a missing packaged Phase 0H exactness script, so the Flash Next depth rows use the same pinned local API route, prompt, sampler, token budget, and max-fan policy as the cross-engine campaign. The harness defect is preserved as infrastructure evidence rather than scored as model failure.

The generic MLX and MTPLX artifacts use different quantization recipes; these are complete-configuration comparisons, not engine-only attribution.

Evidence: `references/results/apple-m5-max-mtplx-20260830.json`.

Verification

- Clean stacked-worktree focused suite: 149 passed.
- MTPLX registry, discovery, telemetry, lifecycle, detach, legacy-Python, distribution, and lineup tests: 33 passed.
- Real owned MTPLX start/status/gateway/completion/stop through Turbofit `auto`: `MTPLX_HARDENED_OK`.
- Status verified `owned_by_turbofit: true` and `lifecycle_status: ready`.
- Ports 18082 and 8091 verified released after stop.
- `git diff --check`: pass.

Repository baseline

The canonical `scripts/release-check` stops at 14 failures inherited from the current base on this Mac. Untouched `main` has the same set plus one stale artifact-manifest assertion (15 total). No new full-suite failure is introduced by either stacked commit.

Stacking

This change intentionally depends on the managed lifecycle and exact gateway model verification in `feat/apple-mlx-runtime`. Review it as a second focused commit; after the generic PR merges, rebase this branch onto `main` without changing its diff.

Out of scope

- Automatic promotion to `auto` on unmeasured Apple hardware.
- Flash Next catalog promotion.
- Public-network serving.
- MTPLX installation or model replacement when the user already has a valid local installation.
